### PR TITLE
Enhancement: Include Bootstrap 3.3.5 (CSS + JS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
   "homepage": "https://github.com/angular-class/angular2-webpack-starter",
   "dependencies": {
     "angular2": "2.0.0-alpha.37",
+    "bootstrap": "^3.3.5",
     "reflect-metadata": "^0.1.1",
     "rx": "^2.5.3",
     "zone.js": "^0.5.4"
   },
   "devDependencies": {
-    "css-loader": "^0.18.0",
+    "css-loader": "^0.19.0",
     "exports-loader": "^0.6.2",
     "expose-loader": "^0.7.0",
     "file-loader": "^0.8.1",
@@ -60,7 +61,7 @@
     "protractor": "^2.1.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.4.3",
-    "style-loader": "^0.12.2",
+    "style-loader": "^0.12.4",
     "tsd": "^0.6.4",
     "typescript": "^1.6.2",
     "typescript-simple-loader": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "angular2": "2.0.0-alpha.37",
     "bootstrap": "^3.3.5",
+    "jquery": "^2.1.4",
     "reflect-metadata": "^0.1.1",
     "rx": "^2.5.3",
     "zone.js": "^0.5.4"

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -74,6 +74,18 @@ class XLarge {
     <pre>this.title = {{ title | json }}</pre>
     <pre>this.data = {{ data | json }}</pre>
 
+    <div>
+      <h3>Bootstrap example (with JS)</h3>
+      <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left"
+        title="Tooltip on left">Tooltip on left</button>
+      <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top"
+        title="Tooltip on top">Tooltip on top</button>
+      <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom"
+        title="Tooltip on bottom">Tooltip on bottom</button>
+      <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right"
+        title="Tooltip on right">Tooltip on right</button>
+    </div>
+
   </main>
 
   <footer x-large>
@@ -113,6 +125,10 @@ export class App {
         // onError callback
         err  => this.errorMessage(err)
       );//end http
+
+
+    // Install Bootstrap's tooltip plugin
+    (<any>$('[data-toggle="tooltip"]')).tooltip();
 
   }
 

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -10,6 +10,9 @@ import {ROUTER_BINDINGS} from 'angular2/router';
 import {ELEMENT_PROBE_BINDINGS} from 'angular2/debug';
 import {HTTP_BINDINGS} from 'angular2/http';
 
+// Include Bootstrap support
+require('bootstrap/dist/css/bootstrap.css');
+
 /*
  * App Component
  * our top level component that holds all of our components

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -11,7 +11,29 @@ import {ELEMENT_PROBE_BINDINGS} from 'angular2/debug';
 import {HTTP_BINDINGS} from 'angular2/http';
 
 // Include Bootstrap support
+// CSS
 require('bootstrap/dist/css/bootstrap.css');
+// Javascript
+// Use the next line to include all scripts (not recommended) ...
+//require('imports?jQuery=jquery!bootstrap/dist/js/bootstrap');
+// ... or include the scripts one by one (recommended)
+const requiredBootstrapPlugins = [
+  //'affix',
+  //'alert',
+  //'button',
+  //'carousel',
+  //'collapse',
+  //'dropdown',
+  //'modal',
+  //'popover',
+  //'scrollspy',
+  //'tab',
+  'tooltip',
+  //'transition'
+];
+requiredBootstrapPlugins.forEach(pluginName => {
+  require(`imports?jQuery=jquery!bootstrap/js/${pluginName}`);
+});
 
 /*
  * App Component

--- a/tsd.json
+++ b/tsd.json
@@ -22,6 +22,12 @@
     },
     "rx/rx-lite.d.ts": {
       "commit": "f6c8ca47193fb67947944a3170912672ac3e908e"
+    },
+    "jquery/jquery.d.ts": {
+      "commit": "705b4cc80bced7c0cc95575741113667d210602f"
+    },
+    "bootstrap/bootstrap.d.ts": {
+      "commit": "54f064352a3615443f7bff4198078db15e28247b"
     }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,10 +157,10 @@ module.exports = {
       },
 
       // Loader for fonts (required for Bootstrap)
-      { test: /\.woff2?($|\?)/, loader: "url?limit=10000&minetype=application/font-woff" },
-      { test: /\.ttf($|\?)/,    loader: "url?limit=10000&minetype=application/octet-stream" },
+      { test: /\.woff2?($|\?)/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /\.ttf($|\?)/,    loader: "url?limit=10000&mimetype=application/octet-stream" },
       { test: /\.eot($|\?)/,    loader: "file" },
-      { test: /\.svg($|\?)/,    loader: "url?limit=10000&minetype=image/svg+xml" }
+      { test: /\.svg($|\?)/,    loader: "url?limit=10000&mimetype=image/svg+xml" }
     ],
     noParse: [
       /rtts_assert\/src\/rtts_assert/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ var UglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
 var DedupePlugin   = webpack.optimize.DedupePlugin;
 var DefinePlugin   = webpack.DefinePlugin;
 var BannerPlugin   = webpack.BannerPlugin;
+var ProvidePlugin  = webpack.ProvidePlugin;
 
 
 /*
@@ -210,6 +211,10 @@ module.exports = {
           'development': 'common.js',
           'all': 'common.min.js'
         })
+      }),
+      new ProvidePlugin({
+        "$": "jquery",
+        "jQuery": "jquery"
       })
     ]
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,8 +128,9 @@ module.exports = {
       // Support for *.json files.
       { test: /\.json$/,  loader: 'json' },
 
-      // Support for CSS as raw text
-      { test: /\.css$/,   loader: 'raw' },
+      // Support for CSS via css-loader + style-loader
+      // see also: https://github.com/webpack/style-loader
+      { test: /\.css$/,   loader: 'style!css' },
 
       // support for .html as raw text
       { test: /\.html$/,  loader: 'raw' },
@@ -152,7 +153,13 @@ module.exports = {
           /test/,
           /node_modules/
         ]
-      }
+      },
+
+      // Loader for fonts (required for Bootstrap)
+      { test: /\.woff2?($|\?)/, loader: "url?limit=10000&minetype=application/font-woff" },
+      { test: /\.ttf($|\?)/,    loader: "url?limit=10000&minetype=application/octet-stream" },
+      { test: /\.eot($|\?)/,    loader: "file" },
+      { test: /\.svg($|\?)/,    loader: "url?limit=10000&minetype=image/svg+xml" }
     ],
     noParse: [
       /rtts_assert\/src\/rtts_assert/,


### PR DESCRIPTION
This PR makes use of Bootstrap 3.3.5 and jQuery 2.1.4. It demonstrates the usage of the tooltip plugin. I would suggest that you don't merge this to master, but make a separate branch that includes Bootstrap.

The PR should fix #16 and #61.

Please note, that it was necessary to include a modified version of the jQuery description (`jquery.d.ts`) to make this work with the rest of the setup. The fix has been provided by [@chaosmail](https://github.com/borisyankov/DefinitelyTyped/issues/2734#issuecomment-118950111). Details on this topic can be found there.