### PR TITLE
ng2-bootstrap + example

### DIFF
--- a/examples/ng2-bootstrap/bootstrap.ts
+++ b/examples/ng2-bootstrap/bootstrap.ts
@@ -1,0 +1,7 @@
+/// <reference path="../typings/_custom.d.ts" />
+
+import {bootstrap} from 'angular2/angular2';
+
+import {App} from './components/app';
+
+bootstrap(App);

--- a/examples/ng2-bootstrap/components/app.ts
+++ b/examples/ng2-bootstrap/components/app.ts
@@ -1,0 +1,23 @@
+/// <reference path="../../typings/_custom.d.ts" />
+/// <reference path="../../../node_modules/ng2-bootstrap/ng2-bootstrap.d.ts" />
+
+require('!!style!css!bootstrap/dist/css/bootstrap.css');
+
+import {Component, View} from 'angular2/angular2';
+import {RouteConfig} from 'angular2/router';
+
+import {Alert} from 'ng2-bootstrap/ng2-bootstrap';
+
+@Component({
+  selector: 'app',
+})
+@View({
+  directives: [ Alert ],
+  template: `
+  <div class="container" style="margin-top: 2em; margin-bottom: 2em;">
+    <alert type="info">Hello world from ng2-bootstrap!</alert>
+  </div>
+  `
+})
+export class App {
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-alpha.4",
     "angular2": "2.0.0-alpha.45",
+    "bootstrap": "^3.3.5",
+    "ng2-bootstrap": "^0.44.6",
     "reflect-metadata": "0.1.2",
     "zone.js": "0.5.8"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,7 @@ module.exports = {
       // './examples/rx-timeflies/bootstrap'
       // './examples/simple-component/bootstrap'
       // './examples/simple-todo/bootstrap'
+      // './examples/ng2-bootstrap/bootstrap'
 
       './src/app/bootstrap'
     ]
@@ -127,10 +128,15 @@ module.exports = {
           /\.spec\.ts$/,
           /\.e2e\.ts$/,
           /web_modules/,
-          /test/,
-          /node_modules/
+          /test/
         ]
-      }
+      },
+
+      // Loader for fonts (required for Bootstrap)
+      { test: /\.woff2?($|\?)/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /\.ttf($|\?)/,    loader: "url?limit=10000&mimetype=application/octet-stream" },
+      { test: /\.eot($|\?)/,    loader: "file" },
+      { test: /\.svg($|\?)/,    loader: "url?limit=10000&mimetype=image/svg+xml" }
     ],
     noParse: [
       /rtts_assert\/src\/rtts_assert/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,7 +128,8 @@ module.exports = {
           /\.spec\.ts$/,
           /\.e2e\.ts$/,
           /web_modules/,
-          /test/
+          /test/,
+          /node_modules\/(?!(ng2-bootstrap))/ // exclude all node modules except ng2-bootstrap
         ]
       },
 


### PR DESCRIPTION
This PR adds `ng2-bootstrap` (as requested in https://github.com/AngularClass/angular2-webpack-starter/pull/83). `ng2-bootstrap` provides the ng2 components, `bootstrap` is purely used for the CSS file. The latter could be replaced with a CDN version, but I prefer to be able to work offline which is why I added also the `bootstrap` dependency.

To make things work, I had to [remove the `/node_modules/` regex](https://github.com/dotcs/angular2-webpack-starter/commit/f6a520138588300f27d6b1042f3d534117c23749#diff-11e9f7f953edc64ba14b0cc350ae7b9dL131) in webpack's typescript module loader definition. I tried to only include the `ng2-bootstrap` module - without success. The regex `node_modules\/((?!(ng2-bootstrap)).)*` did not work, although it should exclude all but the `ng2-bootstrap` folder. If the exclusion of `node_modules` is necessary for any other parts of this project, we should find a way around this issue before merging.

/cc: @gdi2290 