### PR TITLE
Add some simple tests to demonstrate testing directives and components

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -19,7 +19,7 @@ import {ROUTER_DIRECTIVES} from 'angular2/router';
 @Directive({
   selector: '[x-large]' // using [ ] means selecting attributes
 })
-class XLarge {
+export class XLarge {
   constructor(element: ElementRef) {
     // simple DOM manipulation to set font size to x-large
     // `nativeElement` is the direct reference to the DOM element

--- a/test/app/app.spec.ts
+++ b/test/app/app.spec.ts
@@ -1,9 +1,64 @@
 /// <reference path="../../src/typings/_custom.d.ts" />
 
-describe('App', () => {
+// Select BrowserDomAdapter.
+// see https://github.com/AngularClass/angular2-webpack-starter/issues/124
+var domAdapter = require('angular2/src/core/dom/browser_adapter').BrowserDomAdapter;
+domAdapter.makeCurrent();
 
-  it('should also be able to test', () => {
-    expect(true).toBe(true);
-  });
+// Import necessary wrappers for Jasmine
+import {
+  beforeEachProviders,
+  describe,
+  expect,
+  iit,
+  inject,
+  it,
+  injectAsync,
+  fakeAsync,
+  TestComponentBuilder,
+  tick
+} from 'angular2/testing';
+import { Component, provide} from 'angular2/angular2';
+import {MockBackend, BaseRequestOptions, Http} from 'angular2/http';
+
+// Load the implementations that should be tested
+import { App, XLarge } from '../../src/app/app';
+
+// Create a test component to test directives
+@Component({
+  template: '',
+  directives: [XLarge]
+})
+class TestComponent {
+}
+
+describe('x-large directive', () => {
+  it('should sent font-size to x-large', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.overrideTemplate(TestComponent, '<div x-large>Content</div>')
+      .createAsync(TestComponent).then((fixture: any) => {
+        fixture.detectChanges();
+        let compiled = fixture.debugElement.nativeElement.children[0];
+        expect(compiled.style.fontSize).toBe('x-large');
+      });
+  }));
+
+});
+
+describe('App', () => {
+  // provide our implementations or mocks to the dependency injector
+  beforeEachProviders(() => [
+    App,
+    BaseRequestOptions,
+    MockBackend,
+    provide(Http, {useFactory:
+      function(backend, defaultOptions) {
+        return new Http(backend, defaultOptions);
+      },
+      deps: [MockBackend, BaseRequestOptions]})
+  ]);
+
+  it('should have a title', inject([App], (app) => {
+    expect(app.title).toEqual('Angular 2');
+  }));
 
 });

--- a/test/injector.spec.ts
+++ b/test/injector.spec.ts
@@ -1,0 +1,16 @@
+import {
+  it,
+  describe,
+  expect,
+  inject
+} from 'angular2/testing';
+import {
+  APP_ID
+} from 'angular2/angular2';
+
+
+describe('default test injector', () => {
+  it('should provide default id', inject([APP_ID], (id) => {
+    expect(id).toBe('a');
+  }));
+});

--- a/test/sanity_test.spec.ts
+++ b/test/sanity_test.spec.ts
@@ -1,0 +1,5 @@
+describe('sanity checks', () => {
+  it('should also be able to test', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
I have followed the discussion in https://github.com/AngularClass/angular2-webpack-starter/issues/124 and got tests up and running. I have added some simple tests for directives and components. This should be a good starting point for adding more tests that demonstrate also tests of other facets of ng2.