### PR TITLE
Fix : protractor 3.x not compatible with node v0.12.x + chromedriver …

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-webpack": "1.7.0",
     "phantomjs": "^1.9.18",
     "phantomjs-polyfill": "0.0.1",
-    "protractor": "^3.0.0",
+    "protractor": "^2.5.1",
     "raw-loader": "0.5.1",
     "rimraf": "^2.4.4",
     "style-loader": "^0.13.0",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -32,6 +32,17 @@ exports.config = {
     browser.ignoreSynchronization = true;
   },
 
+  /**
+   * For node v0.12.x
+   *
+   * One should install chromedriver locally with : ./node_modules/protractor/bin/webdriver-manager update --standalone
+   *
+   * Otherwise use the chromeDriver option to specify the path to external chromedriver if necessary
+   *
+   * Example : chromeDriver: '/usr/lib/node_modules/protractor/selenium/chromedriver'
+   */
+  directConnect: true,
+
 
   /**
    * Angular 2 configuration


### PR DESCRIPTION
Hi,

I am currently using node v0.12.x on which protractor 3 does not work : i have to fallback to version 2.5.1.

As such, I also faced another issue with chromedriver location : so i put some comments in the protractor conf file to guide people.

I suggest this PR as fix for people who are still using this version of node.
There is actually no specific branch where i can PR, so i PR this on master. 

Please let me know if you create a specific branch for me to PR.

Best regards,
Michel. 