### PR TITLE
spec-bundle.js now requires core-js instead of es6-shim

### DIFF
--- a/spec-bundle.js
+++ b/spec-bundle.js
@@ -10,7 +10,7 @@
 */
 Error.stackTraceLimit = Infinity;
 require('phantomjs-polyfill');
-require('es6-shim');
+require('core-js');
 require('reflect-metadata');
 require('zone.js/dist/zone-microtask.js');
 require('zone.js/dist/long-stack-trace-zone.js');


### PR DESCRIPTION
Unit tests did not run after a fresh clone.

spec-bundle.js was requiring 'es6-shim', updating to core-js appears to have solved this for me.