### PR TITLE
update deprecated imports to 2.0.0-alpha.53

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,7 +1,7 @@
 /*
  * Providers provided by Angular
  */
-import {bootstrap} from 'angular2/bootstrap';
+import {bootstrap} from 'angular2/platform/browser';
 import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
 import {ROUTER_PROVIDERS} from 'angular2/router';
 import {HTTP_PROVIDERS} from 'angular2/http';

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -4,7 +4,6 @@ import 'reflect-metadata';
 import 'zone.js';
 
 // Angular 2
-import 'angular2/bootstrap';
 import 'angular2/platform/browser';
 import 'angular2/platform/common_dom';
 import 'angular2/core';


### PR DESCRIPTION
Due the update from version 2.0.0-alpha.52 to 2.0.0-alpha.53 there are deprecated versions of imports. I added the new imports.