### PR TITLE
Include vendor chunk when creating common chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ module.exports = {
 
   plugins: [
     new CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.js', minChunks: Infinity }),
-    new CommonsChunkPlugin({ name: 'common', filename: 'common.js', minChunks: 2, chunks: ['app'] })
+    new CommonsChunkPlugin({ name: 'common', filename: 'common.js', minChunks: 2, chunks: ['app', 'vendor'] })
   ],
 
   // Other module loader config


### PR DESCRIPTION
See #158.

Changes files sizes from this:
```
     Asset     Size  Chunks             Chunk Names
    app.js   4.8 MB    0, 2  [emitted]  app
 vendor.js  5.45 MB    1, 2  [emitted]  vendor
 common.js  3.65 kB       2  [emitted]  common
   app.map  5.11 MB    0, 2  [emitted]  app
vendor.map  5.91 MB    1, 2  [emitted]  vendor
common.map  3.68 kB       2  [emitted]  common
```

To this:
```
     Asset     Size  Chunks             Chunk Names
    app.js  7.31 kB       0  [emitted]  app
 vendor.js   652 kB       1  [emitted]  vendor
 common.js   4.8 MB       2  [emitted]  common
   app.map  8.14 kB       0  [emitted]  app
vendor.map   800 kB       1  [emitted]  vendor
common.map  5.11 MB       2  [emitted]  common
```


