### PR TITLE
Change es6-shim version to satisfy angular@2.0.0-beta-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "angular2": "2.0.0-beta.0",
     "es6-promise": "^3.0.2",
-    "es6-shim": "^0.34.0",
+    "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "zone.js": "0.5.10"


### PR DESCRIPTION
Removes warning:
```
npm ERR! peerinvalid The package es6-shim@0.34.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer angular2@2.0.0-beta.0 wants es6-shim@^0.33.3
```

As mentioned in #162.