### PR TITLE
Update tsconfig.json error on missing the comma

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
   ],
   "filesGlob": [
     "./src/**/*.ts",
-    "./test/**/*.ts"
+    "./test/**/*.ts",
     "!./node_modules/**/*.ts"
   ],
   "compileOnSave": false,


### PR DESCRIPTION
After having errors on npm start, was a problem related to "./test/**/*.ts" missing the comma after on the tsconfig.json