### PR TITLE
Enable production mode for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clean-start": "npm run clean && npm start",
     "watch": "webpack --watch --progress --profile --colors --display-error-details --display-cached",
     "build": "webpack --progress --profile --colors --display-error-details --display-cached",
-    "build:prod": "webpack --progress --profile --colors --display-error-details --display-cached --optimize-occurence-order --optimize-minimize --optimize-dedupe",
+    "build:prod": "BUILD_PROD=1 webpack --progress --profile --colors --display-error-details --display-cached --optimize-occurence-order --optimize-minimize --optimize-dedupe",
     "server": "webpack-dev-server --inline --progress --profile --colors --display-error-details --display-cached --port 3000",
     "webdriver-update": "webdriver-manager update",
     "webdriver-start": "webdriver-manager start",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -4,10 +4,8 @@
 import {bootstrap} from 'angular2/platform/browser';
 import {ROUTER_PROVIDERS} from 'angular2/router';
 import {HTTP_PROVIDERS} from 'angular2/http';
-// include for development builds
 import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
-// include for production builds
-// import {enableProdMode} from 'angular2/core';
+import {enableProdMode} from 'angular2/core';
 
 /*
  * App Component
@@ -16,17 +14,31 @@ import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
 import {App} from './app/app';
 
 /*
+ * Enable production mode for production build
+ */
+declare var __PRODUCTION__: any;
+
+if (__PRODUCTION__) {
+  enableProdMode();
+}
+
+/*
  * Bootstrap our Angular app with a top level component `App` and inject
  * our Services and Providers into Angular's dependency injection
  */
-// enableProdMode() // include for production builds
 function main() {
-  return bootstrap(App, [
-    // These are dependencies of our App
+
+  // These are dependencies of our App
+  var dependencies = [
     HTTP_PROVIDERS,
     ROUTER_PROVIDERS,
-    ELEMENT_PROBE_PROVIDERS // remove in production
-  ])
+  ];
+
+  if (!__PRODUCTION__) {
+    dependencies.push(ELEMENT_PROBE_PROVIDERS);
+  }
+
+  return bootstrap(App, dependencies)
   .catch(err => console.error(err));
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,10 @@ var webpack = require('webpack');
 // Webpack Plugins
 var CommonsChunkPlugin = webpack.optimize.CommonsChunkPlugin;
 
+var definePlugin = new webpack.DefinePlugin({
+  __PRODUCTION__: JSON.stringify(JSON.parse(process.env.BUILD_PROD || 'false'))
+});
+
 /*
  * Config
  */
@@ -66,7 +70,8 @@ module.exports = {
 
   plugins: [
     new CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.js', minChunks: Infinity }),
-    new CommonsChunkPlugin({ name: 'common', filename: 'common.js', minChunks: 2, chunks: ['app', 'vendor'] })
+    new CommonsChunkPlugin({ name: 'common', filename: 'common.js', minChunks: 2, chunks: ['app', 'vendor'] }),
+    definePlugin
    // include uglify in production
   ],
 


### PR DESCRIPTION
So far in bootstrap.ts file to enable production mode, we have to manually import enableProdMode and again manually call this function. Moreover, we have to remember to remove from dependencies ELEMENT_PROBE_PROVIDERS. This pull request automates this process.