### PR TITLE
feat(sourcemap): Proper source maps for 3rd party packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "remap-istanbul": "^0.5.1",
     "rimraf": "^2.4.4",
     "semver": "*",
+    "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.0",
     "ts-helper": "0.0.1",
     "ts-loader": "^0.8.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,23 @@ module.exports = {
   },
 
   module: {
-    preLoaders: [{ test: /\.ts$/, loader: 'tslint-loader', exclude: [/node_modules/] }],
+    preLoaders: [
+      {
+        test: /\.ts$/,
+        loader: 'tslint-loader',
+        exclude: [/node_modules/]
+      },
+      // rewire source map files of libraries, use to debug into 3rd party libraries
+      {
+        test: /\.js$/,
+        include: [
+          path.resolve(__dirname, "node_modules", "angular2")
+          // Add more as needed or replace to include all modules:
+          //path.resolve(__dirname, "node_modules2")
+        ],
+        loader: "source-map-loader"
+      }
+    ],
     loaders: [
       // Support for .ts files.
       {


### PR DESCRIPTION
Currently, source mapping for external packages are not mapped.

Stepping into code of external packages will step into actual runtime code as supplied to the browser.

```
import {Directive, Component, ElementRef, Renderer} from 'angular2/core';
/*
 * Directive
 * XLarge is a simple directive to show how one is made
 */
@Directive({
  selector: '[x-large]' // using [ ] means selecting attributes
})
export class XLarge {
  constructor(element: ElementRef, renderer: Renderer) {
    // simple DOM manipulation to set font size to x-large
    // `nativeElement` is the direct reference to the DOM element
    // element.nativeElement.style.fontSize = 'x-large';

    // for server/webworker support use the renderer
    debugger;
    renderer.setElementStyle(element.nativeElement, 'fontSize', 'x-large');
  }
}

```

In for code above, stepping into `render.setElementStyle` will go to an instruction showing ES5 transpiled code, not the TypeScript code. This makes it hard to understand what happens and what the angular code wants to do.

This PR adds a webpack `preLoader` that handles the mapping so webpack will use the included sourcemaps in the angular2 package.

Only angular2 source maps added to the configuration with instructions on how to add more.

Add all of the `node_modules` directory is:
A) Build performance hit.
B) Emit `WARNING` messages from `rxjs` package, some sourcemap files are missing there.

I think angular2 is enough, it will help all starters to better understand the framework.