### PR TITLE
disable mangle for now

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -157,7 +157,10 @@ module.exports = {
       // comments: true,//debug
 
       beautify: false,//prod
-      mangle: { screw_ie8 : true },//prod
+      // disable mangling because of a bug in angular2 beta.1
+      // TODO(mastertinner): enable mangling as soon as angular2 beta.2 is out
+      // mangle: { screw_ie8 : true },//prod
+      mangle: false,
       compress : { screw_ie8 : true},//prod
       comments: false//prod
 


### PR DESCRIPTION
mangling is broken in Angular 2 beta.1 as described in #262. That's why it should be disabled until Angular 2 beta.2 is out.