### PR TITLE
Optimize console output for testing

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
     coverageReporter: {
       dir : 'coverage/',
       reporters: [
-        { type: 'text' },
+        { type: 'text-summary' },
         { type: 'json' },
         { type: 'html' }
       ]
@@ -41,7 +41,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: [ 'progress', 'coverage' ],
+    reporters: [ 'mocha', 'coverage' ],
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-coverage": "^0.5.3",
     "karma-jasmine": "^0.3.6",
+    "karma-mocha-reporter": "^1.1.5",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "1.7.0",


### PR DESCRIPTION
To keep track of larger projects, I would like to suggest to use the karma-mocha-reporter and summarize the coverage report. 
If you want to have a look at the coverage per file, the HTML output is much more convenient then displaying the line numbers in the console.

**Before:**
![before](https://cloud.githubusercontent.com/assets/1846056/12742415/cf90cb2a-c985-11e5-9993-f897a004164c.png)
**After:**
![after](https://cloud.githubusercontent.com/assets/1846056/12742419/d502c266-c985-11e5-8b29-01f464a4e5b1.png)

