### PR TITLE
Removed typescript typings install from quick start - Fixes #309

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ cd angular2-webpack-starter
 # install the repo with npm
 npm install
 
-# install TypeScript typings
-npm run typings-install
-
 # start the server
 npm start
 ```


### PR DESCRIPTION
Removed the instruction to install typescript typings as there is already a postinstall npm script that will do that.