### PR TITLE
Webworker are broken without parse5

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "1.7.0",
+    "parse5": "^1.3.2",
     "phantomjs-polyfill": "0.0.1",
     "phantomjs-prebuilt": "^2.1.4",
     "protractor": "^3.1.1",


### PR DESCRIPTION
Regarding to this [issue](https://github.com/angular/angular/issues/7081) parse5 has to be added to the package.json in an older version to make webworkers work.