### PR TITLE
missing semicolon

### DIFF
--- a/src/custom-typings.d.ts
+++ b/src/custom-typings.d.ts
@@ -43,7 +43,7 @@ interface WebpackModule {
     apply(options?: any, callback?: (err?: Error, outdatedModules?: any[]) => void): void;
     status(callback?: (status?: string) => void): void | string;
     removeStatusHandler(callback?: (status?: string) => void): void;
-  }
+  };
 }
 
 interface NodeModule extends WebpackModule {


### PR DESCRIPTION
`src/custom-typings.d.ts[46, 4]: missing semicolon`