### PR TITLE
Fix a missing space in the App class declaration.

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -69,7 +69,7 @@ import {Home} from './home/home';
   { path: '/about', loader: () => require('es6-promise!./about/about')('About'), name: 'About' },
   { path: '/**', redirectTo: ['Index'] }
 ])
-export class App{
+export class App {
   angularclassLogo = 'assets/img/angularclass-avatar.png';
   name = 'Angular 2 Webpack Starter';
   url = 'https://twitter.com/AngularClass';


### PR DESCRIPTION
Hi, 

In trying to build for prod, I get a fail concerning a missing space between the class App and the curly brace.
> src/app/app.ts
> [72, 17]: missing whitespace