### PR TITLE
remove filename from CommonsChunkPlugin to use filename in output with chunkhash

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -127,7 +127,6 @@ module.exports = {
     new OccurenceOrderPlugin(true),
     new CommonsChunkPlugin({
       name: ['main', 'vendor', 'polyfills'],
-      filename: '[name].bundle.js',
       minChunks: Infinity
     }),
     // static assets


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

remove filename from CommonsChunkPlugin to use filename in output with chunkhash

* **What is the current behavior?** (You can also link to an open issue here)

build:prod generates ['main', 'vendor', 'polyfills'].bundle.js

* **What is the new behavior (if this is a feature change)?**

build:prod generates ['main', 'vendor', 'polyfills'].[chunkhash].bundle.js

* **Other information**:

It will allow server to cache js files forever.