### PR TITLE
fix(tests): Provide state dependencies

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -6,12 +6,17 @@ import {
   TestComponentBuilder
 } from 'angular2/testing';
 
+import {WebpackState} from 'angular2-hmr';
+
 // Load the implementations that should be tested
 import {App} from './app';
+import {AppState} from './app.service';
 
 describe('App', () => {
   // provide our implementations or mocks to the dependency injector
   beforeEachProviders(() => [
+    WebpackState,
+    AppState,
     App
   ]);
 

--- a/src/app/home/home.spec.ts
+++ b/src/app/home/home.spec.ts
@@ -10,11 +10,12 @@ import {
 import {Component, provide} from 'angular2/core';
 import {BaseRequestOptions, Http} from 'angular2/http';
 import {MockBackend} from 'angular2/http/testing';
-
+import {WebpackState} from 'angular2-hmr';
 
 // Load the implementations that should be tested
 import {Home} from './home';
 import {Title} from './services/title';
+import {AppState} from '../app.service';
 
 describe('Home', () => {
   // provide our implementations or mocks to the dependency injector
@@ -28,12 +29,14 @@ describe('Home', () => {
       deps: [MockBackend, BaseRequestOptions]
     }),
 
+    WebpackState,
+    AppState,
     Title,
     Home
   ]);
 
   it('should have default data', inject([ Home ], (home) => {
-    expect(home.data).toEqual({ value: '' });
+    expect(home.localState).toEqual({ value: '' });
   }));
 
   it('should have a title', inject([ Home ], (home) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes `app` and `home` unit tests. 


* **What is the current behavior?** (You can also link to an open issue here)
Unit tests are are currently failing due to new dependencies not being provided.

```
npm run test

...

SUMMARY:
✔ 4 tests completed
✖ 4 tests failed

FAILED TESTS:
  App
    ✖ should have a url
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    Failed: No provider for AppState! (App -> AppState)

  Home
    ✖ should have default data
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    Failed: No provider for AppState! (Home -> AppState)

    ✖ should have a title
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    Failed: No provider for AppState! (Home -> AppState)

    ✖ should log ngOnInit
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    Failed: No provider for AppState! (Home -> AppState)
```


* **What is the new behavior (if this is a feature change)?**
```
SUMMARY:
✔ 8 tests completed
```

* **Other information**:
Provided real implementations for `AppState` and `WebpackState`