### PR TITLE
Add support for running on Nitrous

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ npm start
 ```
 go to [http://0.0.0.0:3000](http://0.0.0.0:3000) or [http://localhost:3000](http://localhost:3000) in your browser
 
+# Nitrous Quickstart
+
+You can quickly create a free development environment to get started using this
+starter kit in the cloud on [Nitrous](https://www.nitrous.io/):
+
+<a href="https://www.nitrous.io/quickstart?repo=https://github.com/nitrous-io/angular2-webpack-starter">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+Simply run `HOST=0.0.0.0 npm start` from the terminal inside of
+`~/code/angular2-webpack-starter` and access your site via the "Preview > 3000"
+link in the IDE.
+
 # Table of Contents
 * [File Structure](#file-structure)
 * [Getting Started](#getting-started)

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -20,8 +20,8 @@ const HMR = helpers.hasProcessFlag('hot');
 const METADATA = {
   title: 'Angular2 Webpack Starter by @gdi2990 from @AngularClass',
   baseUrl: '/',
-  host: 'localhost',
-  port: 3000,
+  host: process.env.HOST || 'localhost',
+  port: process.env.PORT || 3000,
   ENV: ENV,
   HMR: HMR
 };

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo 'Installing required NPM global packages...'
+npm install typings webpack-dev-server rimraf webpack -g --no-progress
+echo 'Installing NPM packages...'
+npm install --no-progress
+

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,5 @@
+{
+  "template": "nodejs",
+  "ports": [3000]
+}
+

--- a/src/index.html
+++ b/src/index.html
@@ -54,7 +54,7 @@
 
   <% if (webpackConfig.metadata.ENV === 'development') { %>
   <!-- Webpack Dev Server reload -->
-  <script src="http://<%= webpackConfig.metadata.host %>:<%= webpackConfig.metadata.port %>/webpack-dev-server.js"></script>
+  <script src="/webpack-dev-server.js"></script>
   <% } %>
   
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

This allows developers to conveniently run this starter kit in the "cloud" (where cloud == [Nitrous](https://www.nitrous.io/)).

* **What is the current behavior?**

N/A.

* **What is the new behavior (if this is a feature change)?**

I've added a button to the readme that users can click to create an Ubuntu-powered development environment with the angular2-webpack-starter repository cloned and with its dependencies setup.

* **Other information**:

I'm featuring angular2-webpack-starter on [this page](https://www.nitrous.io/quickstarts/) because it's a great use case for Nitrous.