### PR TITLE
change the order of providers

### DIFF
--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -28,8 +28,8 @@ export function main(initialState = {}) {
   ];
 
   return bootstrap(App, [
-    ...ENV_PROVIDERS,
     ...PROVIDERS,
+    ...ENV_PROVIDERS,
     ...DIRECTIVES,
     ...PIPES,
     ...APP_PROVIDERS,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature: Register ENV_PROVIDERS after PROVIDERS so that default providers can be override by ENV_PROVIDERS

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**: