### PR TITLE
Don't pass default options and remove redundant helpers. Fixes #473

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var zlib = require('zlib');
 
 
 // Helper functions
@@ -9,10 +8,6 @@ console.log('root directory:', root());
 
 function hasProcessFlag(flag) {
   return process.argv.join('').indexOf(flag) > -1;
-}
-
-function gzipMaxLevel(buffer, callback) {
-  return zlib['gzip'](buffer, {level: 9}, callback);
 }
 
 function root(args) {
@@ -66,7 +61,6 @@ function reverse(arr) {
 
 exports.reverse = reverse;
 exports.hasProcessFlag = hasProcessFlag;
-exports.gzipMaxLevel = gzipMaxLevel;
 exports.root = root;
 exports.rootNode = rootNode;
 exports.prependExt = prependExt;

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -164,7 +164,6 @@ module.exports = webpackMerge(commonConfig, {
     //
     // See: https://github.com/webpack/compression-webpack-plugin
     new CompressionPlugin({
-      algorithm: helpers.gzipMaxLevel,
       regExp: /\.css$|\.html$|\.js$|\.map$/,
       threshold: 2 * 1024
     })


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

`npm run build:prod` fails (issue described in #473)

* **What is the new behavior (if this is a feature change)?**

Fixes #473, builds with gzip and compression level of 9 (defaults of compression-webpack-plugin)

* **Other information**:
N/A