### PR TITLE
[Quick Fix] Fixed small typo

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -105,13 +105,13 @@ module.exports = {
       // Returns file content as string
       //
       // See: https://github.com/webpack/raw-loader
-      {test: /\.html$/, loader: 'raw-loader', exclude: [helpers.root('src/index.html')]},
+      {test: /\.css$/, loader: 'raw-loader', exclude: [helpers.root('src/index.html')]},
 
       // Raw loader support for *.html
       // Returns file content as string
       //
       // See: https://github.com/webpack/raw-loader
-      {test: /\.css$/, loader: 'raw-loader', exclude: [helpers.root('src/index.html')]}
+      {test: /\.html$/, loader: 'raw-loader', exclude: [helpers.root('src/index.html')]}
 
     ],
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The comments of the webpack test say that html is loaded but css is loaded. The sam is for css where the comment says it loads css but it loads html. This pull Requests fixes this.


* **What is the current behavior?** (You can also link to an open issue here)
Same as before


* **What is the new behavior (if this is a feature change)?**
Same as before


* **Other information**:
In the comment of the file it sayed that the loader load `*.css` but it actually loaded `.html`.
Same is for the `*.html` comment it loads `.css` files