### PR TITLE
Replaced core-js default import in favour of specific deps import

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -7,7 +7,8 @@
 // import 'es7-reflect-metadata';
 
 // Prefer CoreJS over the polyfills above
-import 'core-js';
+import 'core-js/es6';
+import 'core-js/es7/reflect';
 require('zone.js/dist/zone');
 
 if ('production' === ENV) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Replaced core-js default import in favour of specific deps import

* **What is the current behavior?** (You can also link to an open issue here)

Right now the core-js library is imported as default (Includes all features, standard and non-standard).

* **What is the new behavior (if this is a feature change)?**

Only import from core-js the es6 and es7 reflect shims.

* **Other information**:

