### PR TITLE
Metadata dev fix

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -29,6 +29,11 @@ const METADATA = webpackMerge(commonConfig.metadata, {
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = webpackMerge(commonConfig, {
+  // Merged metadata from webpack.common.js for index.html
+  //
+  // See: (custom attribute)
+  metadata: METADATA,
+
   // Switch loaders to debug mode.
   //
   // See: http://webpack.github.io/docs/configuration.html#debug


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This is a bug fix. The merged metadata from webpack.common.js wasn't exported after being merged. This resulted in index.html not being able to read environment variables.

* **What is the current behavior?**
Currently, metadata that was merged isn't available, only the original metadata from webpack.common.js
#496

* **What is the new behavior (if this is a feature change)?**

This exports the data, as I believe was intended from referencing webpackConfig.metadata.ENV on 
[index.html](https://github.com/AngularClass/angular2-webpack-starter/blob/master/src/index.html) line 55. 

* **Other information**:

webpack.prod.js doesn't export the metadata either, is this something we might want for using within index.html? 
