### PR TITLE
chore: simplify usage of CommonsChunkPlugin

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -207,8 +207,7 @@ module.exports = {
      * See: https://github.com/webpack/docs/wiki/optimization#multi-page-app
      */
     new webpack.optimize.CommonsChunkPlugin({
-      name: helpers.reverse(['polyfills', 'vendor', 'main']),
-      minChunks: Infinity
+      name: helpers.reverse(['polyfills', 'vendor'])
     }),
 
     /*


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It is a chore, simplifies config.

* **What is the current behavior?** (You can also link to an open issue here)

Doesn't change current behavior.

* **What is the new behavior (if this is a feature change)?**

Doesn't change current behavior.

* **Other information**:

You don't need to specify the `main` in here. What webpack is going to do is create a hierarchy (making vendor to be the parent of `main`) and having that `main` there won't add any value. The minChunks is not needed for the current config.

Also, you could drop the reverse helper and just swap the chunks positions.

FWIW, Webpack is smart enough to order the chunks like: polyfills -> vendor -> main so for HtmlWebpackPlugin there is no real need to manually order the chunks.

Cheers.