### PR TITLE
chore: remove extensions at spec-bundle

### DIFF
--- a/config/spec-bundle.js
+++ b/config/spec-bundle.js
@@ -15,9 +15,9 @@ Error.stackTraceLimit = Infinity;
 
 require('core-js');
 
-require('zone.js/dist/zone.js');
-require('zone.js/dist/long-stack-trace-zone.js');
-require('zone.js/dist/jasmine-patch.js');
+require('zone.js/dist/zone');
+require('zone.js/dist/long-stack-trace-zone');
+require('zone.js/dist/jasmine-patch');
 
 // RxJS
 require('rxjs/Rx');


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

simplification

* **What is the current behavior?** (You can also link to an open issue here)

VSC will complain if you leave the extension because it thinks that you want to load the .d.ts and will put a red wiggle on it.

* **What is the new behavior (if this is a feature change)?**

VSC will be happy, apart from that, no issue.

* **Other information**:

![](http://puu.sh/okX6h/7fb8a342a3.png)