### PR TITLE
chore(tsc): don't emit helpers and use maintained polyfill for that i…

### DIFF
--- a/config/spec-bundle.js
+++ b/config/spec-bundle.js
@@ -15,6 +15,9 @@ Error.stackTraceLimit = Infinity;
 
 require('core-js');
 
+// Typescript emit helpers polyfill
+require('ts-helpers');
+
 require('zone.js/dist/zone');
 require('zone.js/dist/long-stack-trace-zone');
 require('zone.js/dist/jasmine-patch');

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "rimraf": "^2.5.2",
     "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.1",
-    "ts-helper": "0.0.1",
+    "ts-helpers": "1.1.0",
     "ts-node": "^0.7.1",
     "tslint": "^3.7.1",
     "tslint-loader": "^2.1.3",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -11,6 +11,9 @@ import 'core-js/es6';
 import 'core-js/es7/reflect';
 require('zone.js/dist/zone');
 
+// Typescript emit helpers polyfill
+import 'ts-helpers';
+
 if ('production' === ENV) {
   // Production
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noEmitHelpers": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It's probably chore/perf/feat because it produces smaller payload size to the user + Code Cov isn't bloated with TS helpers

* **What is the current behavior?** (You can also link to an open issue here)

Ts helpers are emited for every file which uses decorator/extend etc

* **What is the new behavior (if this is a feature change)?**

Ts helpers are not emitted. They are provided just once thanks to `ts-helpers` and TS config tweak

* **Other information**:

…nstead