### PR TITLE
Upgrade copy-webpack-plugin to 2.1.3

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -141,7 +141,8 @@ module.exports = webpackMerge(commonConfig, {
     watchOptions: {
       aggregateTimeout: 300,
       poll: 1000
-    }
+    },
+    outputPath: helpers.root('dist')
   },
 
   /*

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "awesome-typescript-loader": "~0.16.2",
     "codelyzer": "0.0.15",
     "compression-webpack-plugin": "^0.3.1",
-    "copy-webpack-plugin": "^1.1.1",
+    "copy-webpack-plugin": "^2.1.3",
     "css-loader": "^0.23.1",
     "es6-promise": "^3.1.2",
     "es6-promise-loader": "^1.0.1",


### PR DESCRIPTION
When upgrading copy-webpack-plugin, an error stops webpack-dev-server if devServer.outputPath is not given
