### PR TITLE
fix broken tests

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,11 +1,14 @@
 import {
   it,
   inject,
-  injectAsync,
   beforeEachProviders,
   TestComponentBuilder
 } from 'angular2/testing';
-
+import {RootRouter} from 'angular2/src/router/router';
+import {Router, RouteRegistry, ROUTER_PRIMARY_COMPONENT} from 'angular2/router';
+import {Location} from 'angular2/platform/common';
+import {SpyLocation} from 'angular2/src/mock/location_mock';
+import {provide} from 'angular2/core';
 // Load the implementations that should be tested
 import {App} from './app.component';
 import {AppState} from './app.service';
@@ -14,6 +17,10 @@ describe('App', () => {
   // provide our implementations or mocks to the dependency injector
   beforeEachProviders(() => [
     AppState,
+    RouteRegistry,
+    provide(Location, {useClass: SpyLocation}),
+    provide(ROUTER_PRIMARY_COMPONENT, {useValue: App}),
+    provide(Router, {useClass: RootRouter}),
     App
   ]);
 

--- a/src/app/home/x-large/x-large.spec.ts
+++ b/src/app/home/x-large/x-large.spec.ts
@@ -1,7 +1,6 @@
 import {
   it,
   inject,
-  injectAsync,
   describe,
   beforeEachProviders,
   TestComponentBuilder
@@ -22,7 +21,7 @@ describe('x-large directive', () => {
   })
   class TestComponent {}
 
-  it('should sent font-size to x-large', injectAsync([TestComponentBuilder], (tcb) => {
+  it('should sent font-size to x-large', inject([TestComponentBuilder], (tcb) => {
     return tcb.overrideTemplate(TestComponent, '<div x-large>Content</div>')
       .createAsync(TestComponent).then((fixture: any) => {
         fixture.detectChanges();


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for tests.

* **What is the current behavior?** (You can also link to an open issue here)
run with:
node v4.4.3
npm  v3.8.7

got 2 failed tests. I think due to bugs in tests.
✖ should have a url
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    Error: No provider for Router! (App -> Router) in /Users/brianxu/Documents/workspace/lesson-viewer/angular2-webpack-starter/config/spec-bundle.js (line 24726)
✖ should sent font-size to x-large
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    TypeError: undefined is not a constructor (evaluating 'new AsyncTestZoneSpec(finishCallback, failCallback, testName)') in /Users/brianxu/Documents/workspace/lesson-viewer/angular2-webpack-starter/config/spec-bundle.js (line 20165)
    runInAsyncTestZone@/Users/brianxu/Documents/workspace/lesson-viewer/angular2-webpack-starter/config/spec-bundle.js:20165:46 <- webpack:///diffing_plugin_wrapper-output_path-WS3jPtnv.tmp/angular2/src/testing/testing.ts:129:43
    /Users/brianxu/Documents/workspace/lesson-viewer/angular2-webpack-starter/config/spec-bundle.js:20178:36 <- webpack:///diffing_plugin_wrapper-output_path-WS3jPtnv.tmp/angular2/src/testing/testing.ts:145:27

* **What is the new behavior (if this is a feature change)?**



* **Other information**:
I am very new to angular2 so googled around and found some related information:
https://github.com/angular/angular/issues/8232
https://developers.livechatinc.com/blog/testing-angular-2-apps-routeroutlet-and-http/
