### PR TITLE
fix tests

### DIFF
--- a/config/spec-bundle.js
+++ b/config/spec-bundle.js
@@ -21,6 +21,7 @@ require('ts-helpers');
 require('zone.js/dist/zone');
 require('zone.js/dist/long-stack-trace-zone');
 require('zone.js/dist/jasmine-patch');
+require('zone.js/dist/async-test');
 
 // RxJS
 require('rxjs/Rx');

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -85,8 +85,7 @@ export class App {
   url = 'https://twitter.com/AngularClass';
 
   constructor(
-    public appState: AppState,
-    public router: Router) {
+    public appState: AppState) {
 
   }
 

--- a/src/app/home/x-large/x-large.spec.ts
+++ b/src/app/home/x-large/x-large.spec.ts
@@ -1,7 +1,7 @@
 import {
   it,
   inject,
-  injectAsync,
+  async,
   describe,
   beforeEachProviders,
   TestComponentBuilder
@@ -22,13 +22,13 @@ describe('x-large directive', () => {
   })
   class TestComponent {}
 
-  it('should sent font-size to x-large', injectAsync([TestComponentBuilder], (tcb) => {
+  it('should sent font-size to x-large', async(inject([TestComponentBuilder], (tcb) => {
     return tcb.overrideTemplate(TestComponent, '<div x-large>Content</div>')
       .createAsync(TestComponent).then((fixture: any) => {
         fixture.detectChanges();
         let compiled = fixture.debugElement.nativeElement.children[0];
         expect(compiled.style.fontSize).toBe('x-large');
       });
-  }));
+  })));
 
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug: tests failed

* **What is the current behavior?** (You can also link to an open issue here)

2 tests failed

* **What is the new behavior (if this is a feature change)?**

all tests passed

* **Other information**:

From angular's change log:

injectAsync is now deprecated. Instead, use the async function to wrap any asynchronous tests.
You will also need to add the dependency 'node_modules/zone.js/dist/async-test.js' as a served file in your Karma or other test configuration.

Before:

it('should wait for returned promises', injectAsync([FancyService], (service) => {
  return service.getAsyncValue().then((value) => { expect(value).toEqual('async value'); });
}));
it('should wait for returned promises', injectAsync([], () => {
  return somePromise.then(() => { expect(true).toEqual(true); });
}));
After:

it('should wait for returned promises', async(inject([FancyService], (service) => {
  service.getAsyncValue().then((value) => { expect(value).toEqual('async value'); });
})));
// Note that if there is no injection, we no longer need `inject` OR `injectAsync`.
it('should wait for returned promises', async(() => {
  somePromise.then() => { expect(true).toEqual(true); });
}));