### PR TITLE
Style update

### DIFF
--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -14,12 +14,19 @@ console.log('`About` component loaded asynchronously');
     h1 {
       font-family: Arial, Helvetica, sans-serif
     }
+    md-card{
+      margin: 25px;
+    }
   `],
   template: `
   <md-card>
-    <h1>
+    For hot module reloading run
+    <pre>npm run start:hmr</pre>
+  </md-card>
+  <md-card>
+    <h3>
       patrick@AngularClass.com
-    </h1>
+    </h3>
   </md-card>
 
   `

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,56 +20,67 @@ import {RouterActive} from './router-active';
   encapsulation: ViewEncapsulation.None,
   styles: [
     require('normalize.css'),
-    `
-    md-toolbar ul {
-      display: inline;
-      list-style-type: none;
-      margin: 0;
-      padding: 0;
-      width: 60px;
+    `html, body{
+      height: 100%;
+      background: #D0EBE8;
     }
-    md-toolbar li {
-      display: inline;
+    button.active{
+      background: #fff;
+      color: #009688;
     }
-    md-toolbar li.active {
-      background-color: lightgray;
+    button.active:hover{
+      color: #fff;
     }
-  `],
+    .fill{
+      flex: 1 1 auto;
+    }
+    .app-state{
+      margin: 15px;
+      flex: 1;
+    }
+    .home{
+      flex: 1;
+    }
+    md-content{
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+    footer{
+      flex: 0 0 60px;
+      padding: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fff;
+    }`
+  ],
   template: `
-    <header>
+    <md-content>
       <md-toolbar color="primary">
-        <span>{{ name }}</span>
-        <nav>
-          <ul>
-            <li router-active>
-              <a [routerLink]=" ['Index'] ">Index</a>
-            </li>
-            |
-            <li router-active>
-              <a [routerLink]=" ['Home'] ">Home</a>
-            </li>
-            |
-            <li router-active>
-              <a [routerLink]=" ['About'] ">About</a>
-            </li>
-          </ul>
-        </nav>
+          <span>{{ name }}</span>
+          <span class="fill"></span>
+          <button md-button router-active [routerLink]=" ['Index'] ">
+            Index
+          </button>
+          <button md-button router-active [routerLink]=" ['Home'] ">
+            Home
+          </button>
+          <button md-button router-active [routerLink]=" ['About'] ">
+            About
+          </button>
       </md-toolbar>
-    </header>
-    <md-progress-bar mode="indeterminate" color="primary" *ngIf="loading"></md-progress-bar>
+      
+      <md-progress-bar mode="indeterminate" color="primary" *ngIf="loading"></md-progress-bar>
 
-    <main>
       <router-outlet></router-outlet>
-    </main>
 
-    <pre>this.appState.state = {{ appState.state | json }}</pre>
+      <pre class="app-state">this.appState.state = {{ appState.state | json }}</pre>
 
-    <footer>
-      WebPack Angular 2 Starter by <a [href]="url">@AngularClass</a>
-      <div>
-        <img [src]="angularclassLogo" width="10%">
-      </div>
-    </footer>
+      <footer>
+        <img [src]="angularclassLogo" width="6%">WebPack Angular 2 Starter by <a [href]="url">@AngularClass</a>
+      </footer>
+      </md-content>
   `
 })
 @RouteConfig([

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,7 +22,7 @@ import {RouterActive} from './router-active';
     require('normalize.css'),
     `html, body{
       height: 100%;
-      background: #D0EBE8;
+      background: #F4FAFA;
     }
     button.active{
       background: #fff;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -78,7 +78,8 @@ import {RouterActive} from './router-active';
       <pre class="app-state">this.appState.state = {{ appState.state | json }}</pre>
 
       <footer>
-        <img [src]="angularclassLogo" width="6%">WebPack Angular 2 Starter by <a [href]="url">@AngularClass</a>
+        <img [src]="angularclassLogo" width="6%">
+        WebPack Angular 2 Starter by <a [href]="url">@AngularClass</a>
       </footer>
       </md-content>
   `

--- a/src/app/home/home.css
+++ b/src/app/home/home.css
@@ -1,0 +1,14 @@
+/*styles for home content only*/
+.card-container{
+    display: flex;
+    flex-direction: column;
+    margin: 15px;
+    
+    border: 2px dashed #FBC02D;
+}
+.sample-content{
+    flex: 1;
+}
+.card-container md-card{
+    margin: 5px;
+}

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -1,31 +1,30 @@
-<md-card>
-  <md-card-content>
-    <span x-large>Your Content Here</span>
+<div class="card-container">
+  <md-card x-large class="sample-content">Your Content Here</md-card>
+  <md-card>
+    <md-card-title>Local State</md-card-title>
+    <md-card-content>
 
-    <form (ngSubmit)="submitState(localState.value)" autocomplete="off">
+      <form (ngSubmit)="submitState(localState.value)" autocomplete="off">
 
-      <md-input
-        placeholder="Submit Local State to App State"
-        [value]="localState.value"
-        (input)="localState.value = $event.target.value"
-        autofocus>
-      </md-input>
+        <md-input
+          placeholder="Submit Local State to App State"
+          [value]="localState.value"
+          (input)="localState.value = $event.target.value"
+          autofocus>
+        </md-input>
 
-      <button md-raised-button color="primary">Submit Value</button>
-    </form>
-    <!--
-      <input type="text" [value]="localState.value" (input)="localState.value = $event.target.value" autofocus>
-      Rather than wiring up two-way data-binding ourselves with [value] and (input)
-      we can use Angular's [(ngModel)] syntax
-      <input type="text" [(ngModel)]="localState.value" autofocus>
-    -->
-    <md-card>
-      For hot module reloading run
-      <pre>npm run start:hmr</pre>
-    </md-card>
+        <button md-raised-button color="primary">Submit Value</button>
+      </form>
+      <!--
+        <input type="text" [value]="localState.value" (input)="localState.value = $event.target.value" autofocus>
+        Rather than wiring up two-way data-binding ourselves with [value] and (input)
+        we can use Angular's [(ngModel)] syntax
+        <input type="text" [(ngModel)]="localState.value" autofocus>
+      -->
 
-    <hr>
-    <pre>this.localState = {{ localState | json }}</pre>
+      <pre>this.localState = {{ localState | json }}</pre>
 
-  </md-card-content>
-</md-card>
+    </md-card-content>
+  </md-card>
+  
+</div>


### PR DESCRIPTION
- updates the nav bar to current material standard
- adds styles for the buttons on the nav bar to make the active state more obvious
- moves the reload instructions to the about page
- change layout for the footer
- change layout of page to make sections clearer
- add margins to cards
- use multiple forms of css and alternate margins to illustrate isolating styles


![screen shot 2016-05-06 at 10 05 24 am](https://cloud.githubusercontent.com/assets/3473924/15079104/caa4f108-1373-11e6-8d13-134f336ddd6d.png)
![screen shot 2016-05-06 at 10 05 57 am](https://cloud.githubusercontent.com/assets/3473924/15079107/ce427574-1373-11e6-8fa1-a26f1d054bf7.png)


