### PR TITLE
simplify HtmlWebpackPlugin options

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -244,7 +244,7 @@ module.exports = {
      */
     new HtmlWebpackPlugin({
       template: 'src/index.html',
-      chunksSortMode: helpers.packageSort(['polyfills', 'vendor', 'main'])
+      chunksSortMode: 'dependency'
     })
 
   ],


### PR DESCRIPTION
`chunksSortMode: 'dependency'` should sort your injects correctly, without helper function, also will be the default behavior in webpack2