### PR TITLE
Style: 03-05 and 03-06

### DIFF
--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
 
 /*
  * We're loading this component asynchronously

--- a/src/app/about/about.spec.ts
+++ b/src/app/about/about.spec.ts
@@ -5,12 +5,12 @@ import {
   describe,
   beforeEachProviders
 } from '@angular/core/testing';
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import { TestComponentBuilder } from '@angular/compiler/testing';
 
-import {Component, provide} from '@angular/core';
+import { Component, provide } from '@angular/core';
 
 // Load the implementations that should be tested
-import {About} from './about.component';
+import { About } from './about.component';
 
 describe('About', () => {
   // provide our implementations or mocks to the dependency injector

--- a/src/app/about/about.spec.ts
+++ b/src/app/about/about.spec.ts
@@ -1,13 +1,12 @@
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component, provide } from '@angular/core';
 import {
-  it,
+  beforeEachProviders,
+  describe,
   inject,
   injectAsync,
-  describe,
-  beforeEachProviders
+  it
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
-
-import { Component, provide } from '@angular/core';
 
 // Load the implementations that should be tested
 import { About } from './about.component';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,8 +4,8 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { RouteConfig, Router } from '@angular/router-deprecated';
 
-import { Home } from './home';
 import { AppState } from './app.service';
+import { Home } from './home';
 import { RouterActive } from './router-active';
 
 /*

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,12 @@
 /*
  * Angular 2 decorators and services
  */
-import {Component, ViewEncapsulation} from '@angular/core';
-import {RouteConfig, Router} from '@angular/router-deprecated';
+import { Component, ViewEncapsulation } from '@angular/core';
+import { RouteConfig, Router } from '@angular/router-deprecated';
 
-import {Home} from './home';
-import {AppState} from './app.service';
-import {RouterActive} from './router-active';
+import { Home } from './home';
+import { AppState } from './app.service';
+import { RouterActive } from './router-active';
 
 /*
  * App Component

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -1,5 +1,5 @@
-import {Injectable} from '@angular/core';
-import {HmrState} from 'angular2-hmr';
+import { Injectable } from '@angular/core';
+import { HmrState } from 'angular2-hmr';
 
 @Injectable()
 export class AppState {

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -6,8 +6,8 @@ import {
 } from '@angular/core/testing';
 
 // Load the implementations that should be tested
-import {App} from './app.component';
-import {AppState} from './app.service';
+import { App } from './app.component';
+import { AppState } from './app.service';
 
 describe('App', () => {
   // provide our implementations or mocks to the dependency injector

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,8 +1,8 @@
 import {
-  it,
+  beforeEachProviders,
   inject,
   injectAsync,
-  beforeEachProviders
+  it
 } from '@angular/core/testing';
 
 // Load the implementations that should be tested

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
-import { AppState } from '../app.service';
 
+import { AppState } from '../app.service';
 import { Title } from './title';
 import { XLarge } from './x-large';
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,8 +1,8 @@
-import {Component} from '@angular/core';
-import {AppState} from '../app.service';
+import { Component } from '@angular/core';
+import { AppState } from '../app.service';
 
-import {Title} from './title';
-import {XLarge} from './x-large';
+import { Title } from './title';
+import { XLarge } from './x-large';
 
 @Component({
   // The selector is what angular internally uses

--- a/src/app/home/home.spec.ts
+++ b/src/app/home/home.spec.ts
@@ -1,19 +1,18 @@
+import { Component } from '@angular/core';
 import {
-  it,
+  beforeEachProviders,
+  describe,
   inject,
   injectAsync,
-  describe,
-  beforeEachProviders
+  it
 } from '@angular/core/testing';
-
-import { Component } from '@angular/core';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 
 // Load the implementations that should be tested
+import { AppState } from '../app.service';
 import { Home } from './home.component';
 import { Title } from './title';
-import { AppState } from '../app.service';
 
 describe('Home', () => {
   // provide our implementations or mocks to the dependency injector

--- a/src/app/home/home.spec.ts
+++ b/src/app/home/home.spec.ts
@@ -6,14 +6,14 @@ import {
   beforeEachProviders
 } from '@angular/core/testing';
 
-import {Component} from '@angular/core';
-import {BaseRequestOptions, Http} from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
+import { Component } from '@angular/core';
+import { BaseRequestOptions, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
 
 // Load the implementations that should be tested
-import {Home} from './home.component';
-import {Title} from './title';
-import {AppState} from '../app.service';
+import { Home } from './home.component';
+import { Title } from './title';
+import { AppState } from '../app.service';
 
 describe('Home', () => {
   // provide our implementations or mocks to the dependency injector

--- a/src/app/home/title/title.service.ts
+++ b/src/app/home/title/title.service.ts
@@ -1,5 +1,5 @@
-import {Injectable} from '@angular/core';
-import {Http} from '@angular/http';
+import { Injectable } from '@angular/core';
+import { Http } from '@angular/http';
 
 @Injectable()
 export class Title {

--- a/src/app/home/title/title.spec.ts
+++ b/src/app/home/title/title.spec.ts
@@ -4,14 +4,14 @@ import {
   injectAsync,
   beforeEachProviders
 } from '@angular/core/testing';
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import { TestComponentBuilder } from '@angular/compiler/testing';
 
-import {Component, provide} from '@angular/core';
-import {BaseRequestOptions, Http} from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
+import { Component, provide } from '@angular/core';
+import { BaseRequestOptions, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
 
 
-import {Title} from './title.service';
+import { Title } from './title.service';
 
 describe('Title', () => {
   beforeEachProviders(() => [

--- a/src/app/home/title/title.spec.ts
+++ b/src/app/home/title/title.spec.ts
@@ -1,15 +1,13 @@
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component, provide } from '@angular/core';
 import {
-  it,
+  beforeEachProviders,
   inject,
   injectAsync,
-  beforeEachProviders
+  it
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
-
-import { Component, provide } from '@angular/core';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
-
 
 import { Title } from './title.service';
 

--- a/src/app/home/x-large/x-large.directive.ts
+++ b/src/app/home/x-large/x-large.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, Component, ElementRef, Renderer} from '@angular/core';
+import { Directive, Component, ElementRef, Renderer } from '@angular/core';
 /*
  * Directive
  * XLarge is a simple directive to show how one is made

--- a/src/app/home/x-large/x-large.directive.ts
+++ b/src/app/home/x-large/x-large.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Component, ElementRef, Renderer } from '@angular/core';
+import { Component, Directive, ElementRef, Renderer } from '@angular/core';
 /*
  * Directive
  * XLarge is a simple directive to show how one is made

--- a/src/app/home/x-large/x-large.spec.ts
+++ b/src/app/home/x-large/x-large.spec.ts
@@ -1,13 +1,12 @@
-import {
-  it,
-  inject,
-  async,
-  describe,
-  beforeEachProviders
-} from '@angular/core/testing';
 import { TestComponentBuilder } from '@angular/compiler/testing';
-
 import { Component, provide } from '@angular/core';
+import {
+  async,
+  beforeEachProviders,
+  describe,
+  inject,
+  it
+} from '@angular/core/testing';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 

--- a/src/app/home/x-large/x-large.spec.ts
+++ b/src/app/home/x-large/x-large.spec.ts
@@ -5,14 +5,14 @@ import {
   describe,
   beforeEachProviders
 } from '@angular/core/testing';
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import { TestComponentBuilder } from '@angular/compiler/testing';
 
-import {Component, provide} from '@angular/core';
-import {BaseRequestOptions, Http} from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
+import { Component, provide } from '@angular/core';
+import { BaseRequestOptions, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
 
 // Load the implementations that should be tested
-import {XLarge} from './x-large.directive';
+import { XLarge } from './x-large.directive';
 
 describe('x-large directive', () => {
   // Create a test component to test directives

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -2,7 +2,7 @@
 export * from './app.component';
 export * from './app.service';
 
-import {AppState} from './app.service';
+import { AppState } from './app.service';
 
 // Application wide providers
 export const APP_PROVIDERS = [

--- a/src/app/router-active/router-active.directive.ts
+++ b/src/app/router-active/router-active.directive.ts
@@ -1,16 +1,15 @@
-import { Router } from '@angular/router-deprecated';
-import { isPresent } from '@angular/core/src/facade/lang';
 import {
+  Attribute,
   Directive,
+  ElementRef,
+  Input,
+  Optional,
   Query,
   QueryList,
-  Attribute,
-  ElementRef,
-  Renderer,
-  Optional,
-  Input
+  Renderer
 } from '@angular/core';
-import { Instruction, RouterLink } from '@angular/router-deprecated';
+import { isPresent } from '@angular/core/src/facade/lang';
+import { Instruction, Router, RouterLink } from '@angular/router-deprecated';
 
 /**
  * RouterActive dynamically finds the first element with routerLink and toggles the active class

--- a/src/app/router-active/router-active.directive.ts
+++ b/src/app/router-active/router-active.directive.ts
@@ -1,5 +1,5 @@
-import {Router} from '@angular/router-deprecated';
-import {isPresent} from '@angular/core/src/facade/lang';
+import { Router } from '@angular/router-deprecated';
+import { isPresent } from '@angular/core/src/facade/lang';
 import {
   Directive,
   Query,
@@ -10,7 +10,7 @@ import {
   Optional,
   Input
 } from '@angular/core';
-import {Instruction, RouterLink} from '@angular/router-deprecated';
+import { Instruction, RouterLink } from '@angular/router-deprecated';
 
 /**
  * RouterActive dynamically finds the first element with routerLink and toggles the active class

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -1,19 +1,19 @@
 /*
  * Providers provided by Angular
  */
-import {bootstrap} from '@angular/platform-browser-dynamic';
+import { bootstrap } from '@angular/platform-browser-dynamic';
 /*
 * Platform and Environment
 * our providers/directives/pipes
 */
-import {DIRECTIVES, PIPES, PROVIDERS} from './platform/browser';
-import {ENV_PROVIDERS} from './platform/environment';
+import { DIRECTIVES, PIPES, PROVIDERS } from './platform/browser';
+import { ENV_PROVIDERS } from './platform/environment';
 
 /*
 * App Component
 * our top level component that holds all of our components
 */
-import {App, APP_PROVIDERS} from './app';
+import { App, APP_PROVIDERS } from './app';
 
 /*
  * Bootstrap our Angular app with a top level component `App` and inject

--- a/src/platform/browser/angular2-material2/index.ts
+++ b/src/platform/browser/angular2-material2/index.ts
@@ -1,13 +1,13 @@
-import {MdButton, MdAnchor} from '@angular2-material/button';
-import {MD_CARD_DIRECTIVES} from '@angular2-material/card';
-import {MdCheckbox} from '@angular2-material/checkbox';
-import {MD_SIDENAV_DIRECTIVES} from '@angular2-material/sidenav';
-import {MD_INPUT_DIRECTIVES} from '@angular2-material/input';
-import {MD_LIST_DIRECTIVES} from '@angular2-material/list';
-import {MdRadioGroup, MdRadioButton, MdRadioDispatcher} from '@angular2-material/radio';
-import {MdProgressBar} from '@angular2-material/progress-bar';
-import {MdSpinner, MdProgressCircle} from '@angular2-material/progress-circle';
-import {MdToolbar} from '@angular2-material/toolbar';
+import { MdButton, MdAnchor } from '@angular2-material/button';
+import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
+import { MdCheckbox } from '@angular2-material/checkbox';
+import { MD_SIDENAV_DIRECTIVES } from '@angular2-material/sidenav';
+import { MD_INPUT_DIRECTIVES } from '@angular2-material/input';
+import { MD_LIST_DIRECTIVES } from '@angular2-material/list';
+import { MdRadioGroup, MdRadioButton, MdRadioDispatcher } from '@angular2-material/radio';
+import { MdProgressBar } from '@angular2-material/progress-bar';
+import { MdSpinner, MdProgressCircle } from '@angular2-material/progress-circle';
+import { MdToolbar } from '@angular2-material/toolbar';
 
 /*
  * we are grouping the module so we only need to manage the imports in one location

--- a/src/platform/browser/angular2-material2/index.ts
+++ b/src/platform/browser/angular2-material2/index.ts
@@ -1,12 +1,12 @@
-import { MdButton, MdAnchor } from '@angular2-material/button';
+import { MdAnchor, MdButton } from '@angular2-material/button';
 import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
 import { MdCheckbox } from '@angular2-material/checkbox';
-import { MD_SIDENAV_DIRECTIVES } from '@angular2-material/sidenav';
 import { MD_INPUT_DIRECTIVES } from '@angular2-material/input';
 import { MD_LIST_DIRECTIVES } from '@angular2-material/list';
-import { MdRadioGroup, MdRadioButton, MdRadioDispatcher } from '@angular2-material/radio';
 import { MdProgressBar } from '@angular2-material/progress-bar';
-import { MdSpinner, MdProgressCircle } from '@angular2-material/progress-circle';
+import { MdProgressCircle, MdSpinner } from '@angular2-material/progress-circle';
+import { MdRadioButton, MdRadioDispatcher, MdRadioGroup } from '@angular2-material/radio';
+import { MD_SIDENAV_DIRECTIVES } from '@angular2-material/sidenav';
 import { MdToolbar } from '@angular2-material/toolbar';
 
 /*

--- a/src/platform/browser/directives.ts
+++ b/src/platform/browser/directives.ts
@@ -2,14 +2,14 @@
  * These are globally available directives in any template
  */
 
-import {PLATFORM_DIRECTIVES} from '@angular/core';
+import { PLATFORM_DIRECTIVES } from '@angular/core';
 
 // Angular 2 Router
-import {ROUTER_DIRECTIVES} from '@angular/router-deprecated';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 // Angular 2 Material 2
 // TODO(gdi2290): replace with @angular2-material/all
-import {MATERIAL_DIRECTIVES} from './angular2-material2';
+import { MATERIAL_DIRECTIVES } from './angular2-material2';
 
 // application_directives: directives that are global through out the application
 export const APPLICATION_DIRECTIVES = [

--- a/src/platform/browser/directives.ts
+++ b/src/platform/browser/directives.ts
@@ -3,7 +3,6 @@
  */
 
 import { PLATFORM_DIRECTIVES } from '@angular/core';
-
 // Angular 2 Router
 import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 

--- a/src/platform/browser/pipes.ts
+++ b/src/platform/browser/pipes.ts
@@ -2,7 +2,7 @@
  * These are globally available pipes in any template
  */
 
-import {PLATFORM_PIPES} from '@angular/core';
+import { PLATFORM_PIPES } from '@angular/core';
 
 // application_pipes: pipes that are global through out the application
 export const APPLICATION_PIPES = [

--- a/src/platform/browser/providers.ts
+++ b/src/platform/browser/providers.ts
@@ -3,16 +3,16 @@
  */
 
 // Angular 2
-import {FORM_PROVIDERS, LocationStrategy, HashLocationStrategy} from '@angular/common';
+import { FORM_PROVIDERS, LocationStrategy, HashLocationStrategy } from '@angular/common';
 
 // Angular 2 Http
-import {HTTP_PROVIDERS} from '@angular/http';
+import { HTTP_PROVIDERS } from '@angular/http';
 // Angular 2 Router
-import {ROUTER_PROVIDERS} from '@angular/router-deprecated';
+import { ROUTER_PROVIDERS } from '@angular/router-deprecated';
 
 // Angular 2 Material
 // TODO(gdi2290): replace with @angular2-material/all
-import {MATERIAL_PROVIDERS} from './angular2-material2';
+import { MATERIAL_PROVIDERS } from './angular2-material2';
 
 /*
 * Application Providers/Directives/Pipes

--- a/src/platform/browser/providers.ts
+++ b/src/platform/browser/providers.ts
@@ -3,8 +3,7 @@
  */
 
 // Angular 2
-import { FORM_PROVIDERS, LocationStrategy, HashLocationStrategy } from '@angular/common';
-
+import { FORM_PROVIDERS, HashLocationStrategy, LocationStrategy } from '@angular/common';
 // Angular 2 Http
 import { HTTP_PROVIDERS } from '@angular/http';
 // Angular 2 Router

--- a/src/platform/environment.ts
+++ b/src/platform/environment.ts
@@ -1,6 +1,6 @@
 
 // Angular 2
-import {enableProdMode} from '@angular/core';
+import { enableProdMode } from '@angular/core';
 
 // Environment Providers
 let PROVIDERS = [];


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Update to conform to [Angular Style Guide](https://angular.io/styleguide)

* **What is the current behavior?** (You can also link to an open issue here)

some source files violate Coding Conventions rules on Import Destructuring Spacing (03-05) and Import Line Spacing (03-06)

* **What is the new behavior (if this is a feature change)?**

source conforms to style guide rules 03-05 and 03-06

* **Other information**:

Style 03-05: Import Destructuring Spacing
-Do leave one whitespace character inside of the import statements' curly braces when destructuring.
-Why? Whitespace makes it easier to read the imports.

Style 03-06: Import Line Spacing
-Do leave one empty line between third party imports and imports of code we created.
-Do list import lines alphabetized by the module.
-Do list destructured imported assets alphabetically.
-Why? The empty line makes it easy to read and locate imports.
-Why? Alphabetizing makes it easier to read and locate imports.