### PR TITLE
tsconfig.json fix for 1.0.4 typings release

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,15 @@
     "noEmitHelpers": true
   },
   "exclude": [
-    "node_modules"
+    "./node_modules",
+    "./typings/main.d.ts",
+    "./typings/main"
+  ],
+  "filesGlob": [
+    "./src/client/**/*.ts",
+    "!./node_modules/**",
+    "./src/client/custom-typings.d.ts",
+    "./typings/index.d.ts"
   ],
   "awesomeTypescriptLoaderOptions": {
     "resolveGlobs": true,
@@ -18,3 +26,4 @@
   "buildOnSave": false,
   "atom": { "rewriteTsconfig": false }
 }
+


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
[these comments](https://github.com/AngularClass/angular2-webpack-starter/commit/fe6a1def8e071ed3548ada3847b2945ae338a596#commitcomment-17516133)


* **What is the current behavior?** (You can also link to an open issue here)
typing errors and `duplicate identifier` issues


* **What is the new behavior (if this is a feature change)?**
point to moved typings/index.d.ts changed in 1.0.4 update


