### PR TITLE
fix: webpack-dev-server.js will 404 on build:dev

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -13,6 +13,9 @@ function hasProcessFlag(flag) {
   return process.argv.join('').indexOf(flag) > -1;
 }
 
+function isWebpackDevServer() {
+  return process.argv[1] && !! (/webpack-dev-server$/.exec(process.argv[1]));
+}
 function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [ROOT].concat(args));
@@ -20,4 +23,5 @@ function root(args) {
 
 
 exports.hasProcessFlag = hasProcessFlag;
+exports.isWebpackDevServer = isWebpackDevServer;
 exports.root = root;

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -16,6 +16,7 @@ function hasProcessFlag(flag) {
 function isWebpackDevServer() {
   return process.argv[1] && !! (/webpack-dev-server$/.exec(process.argv[1]));
 }
+
 function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [ROOT].concat(args));

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -13,12 +13,16 @@ var CopyWebpackPlugin = (CopyWebpackPlugin = require('copy-webpack-plugin'), Cop
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ForkCheckerPlugin = require('awesome-typescript-loader').ForkCheckerPlugin;
 
+if (helpers.hasProcessFlag())
+console.log(process.argv);
+
 /*
  * Webpack Constants
  */
 const METADATA = {
   title: 'Angular2 Webpack Starter by @gdi2290 from @AngularClass',
-  baseUrl: '/'
+  baseUrl: '/',
+  isDevServer: helpers.isWebpackDevServer()
 };
 
 /*

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -13,9 +13,6 @@ var CopyWebpackPlugin = (CopyWebpackPlugin = require('copy-webpack-plugin'), Cop
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ForkCheckerPlugin = require('awesome-typescript-loader').ForkCheckerPlugin;
 
-if (helpers.hasProcessFlag())
-console.log(process.argv);
-
 /*
  * Webpack Constants
  */

--- a/src/index.html
+++ b/src/index.html
@@ -52,11 +52,11 @@
     ga('send', 'pageview');
   </script>
 
-  <% if (webpackConfig.metadata.ENV === 'development') { %>
+  <% if (webpackConfig.metadata.isDevServer) { %>
   <!-- Webpack Dev Server reload -->
   <script src="/webpack-dev-server.js"></script>
   <% } %>
-  
+
 
 </body>
 </html>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When creating a build using `build:dev` the index.html request a javascript resource **webpack-dev-server.js**.
**webpack-dev-server.js** is used by `webpack-dev-server` which also returns it (the resource).
Since a build is intended to run in a different web server it will always 404.


* **What is the new behavior (if this is a feature change)?**
Do not include 'webpack-dev-server.js` script request in builds, only include it when running udner `webpack-dev-server`


* **Other information**:
The current implementation uses **ENV** to determine if were in development mode, if so include `webpack-dev-server.js`. A build can also be a development mode. To get the real answer a helper function checks for the file used to run the process, if its `webpack-dev-server` then we include the resource.
