### PR TITLE
GitHub deployment script into gh-pages - dev or prod builds.

### DIFF
--- a/config/github-deploy/index.js
+++ b/config/github-deploy/index.js
@@ -1,0 +1,59 @@
+const helpers = require('../helpers');
+const execSync = require('child_process').execSync;
+
+const REPO_NAME_RE = /Push  URL: https:\/\/github\.com\/.*\/(.*)\.git/;
+
+function getWebpackConfigModule() {
+  if (helpers.hasProcessFlag('github-dev')) {
+    return require('../webpack.dev.js');
+  } else if (helpers.hasProcessFlag('github-prod')) {
+    return require('../webpack.prod.js');
+  } else {
+    throw new Error('Invalid compile option.');
+  }
+}
+
+function getRepoName(remoteName) {
+  remoteName = remoteName || 'origin';
+
+  var stdout = execSync('git remote show ' + remoteName),
+      match = REPO_NAME_RE.exec(stdout);
+
+  if (!match) {
+    throw new Error('Could not find a repository on remote ' + remoteName);
+  } else {
+    return match[1];
+  }
+}
+
+function stripTrailing(str, char) {
+
+  if (str[0] === char) {
+    str = str.substr(1);
+  }
+
+  if(str.substr(-1) === char) {
+    str = str.substr(0, str.length - 1);
+  }
+
+  return str;
+}
+
+/**
+ * Given a string remove trailing slashes and adds 1 slash at the end of the string.
+ *
+ * Example:
+ * safeUrl('/value/')
+ * // 'value/'
+ *
+ * @param url
+ * @returns {string}
+ */
+function safeUrl(url) {
+  const stripped = stripTrailing(url || '', '/');
+  return stripped ? stripped + '/' : ''
+}
+
+exports.getWebpackConfigModule = getWebpackConfigModule;
+exports.getRepoName = getRepoName;
+exports.safeUrl = safeUrl;

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -59,7 +59,7 @@ module.exports = {
     'main':      './src/main.browser.ts'
 
   },
-
+  
   /*
    * Options affecting the resolving of modules.
    *

--- a/config/webpack.github-deploy.js
+++ b/config/webpack.github-deploy.js
@@ -1,0 +1,79 @@
+/**
+ * @author: @AngularClass
+ */
+const helpers = require('./helpers');
+const ghDeploy = require('./github-deploy');
+const webpackMerge = require('webpack-merge'); // used to merge webpack configs
+const ghpages = require('gh-pages');
+const webpackConfig = ghDeploy.getWebpackConfigModule(); // the settings that are common to prod and dev
+
+
+/**
+ * Webpack Constants
+ */
+const GIT_REMOTE_NAME = 'origin';
+const COMMIT_MESSAGE = 'Updates';
+const GH_REPO_NAME = ghDeploy.getRepoName(GIT_REMOTE_NAME);
+
+const METADATA = webpackMerge(webpackConfig.metadata, {
+  /**
+   * Prefixing the REPO name to the baseUrl for router support.
+   * This also means all resource URIs (CSS/Images/JS) will have this prefix added by the browser
+   * unless they are absolute (start with '/'). We will handle it via `output.publicPath`
+   */
+  baseUrl: '/' + GH_REPO_NAME + '/' + ghDeploy.safeUrl(webpackConfig.metadata.baseUrl)
+});
+
+module.exports = webpackMerge(webpackConfig, {
+  /**
+   * Merged metadata from webpack.common.js for index.html
+   *
+   * See: (custom attribute)
+   */
+  metadata: METADATA,
+
+
+  output: {
+    /**
+     * The public path is set to the REPO name.
+     *
+     * `HtmlElementsPlugin` will add it to all resources url's created by it.
+     * `HtmlWebpackPlugin` will add it to all webpack bundels/chunks.
+     *
+     * In theory publicPath shouldn't be used since the browser should automatically prefix the
+     * `baseUrl` into all URLs, however this is not the case when the URL is absolute (start with /)
+     *
+     * It's important to prefix & suffix the repo name with a slash (/).
+     * Prefixing so every resource will be absolute (otherwise it will be url.com/repoName/repoName...
+     * Suffixing since chunks will not do it automatically (testes against about page)
+     */
+    publicPath: '/' + GH_REPO_NAME + '/' + ghDeploy.safeUrl(webpackConfig.output.publicPath)
+  },
+
+  plugins: [
+    function() {
+      this.plugin("done", function(stats) {
+        console.log('Starting deployment to GitHub.');
+
+        const logger = function (msg) {
+          console.log(msg);
+        };
+
+        const options = {
+          logger: logger,
+          remote: GIT_REMOTE_NAME,
+          message: COMMIT_MESSAGE
+        };
+
+        ghpages.publish(webpackConfig.output.path, options, function(err) {
+          if (err) {
+            console.log('GitHub deployment done. STATUS: ERROR.');
+            throw err;
+          } else {
+            console.log('GitHub deployment done. STATUS: SUCCESS.');
+          }
+        });
+      })
+    }
+  ]
+});

--- a/package.json
+++ b/package.json
@@ -39,7 +39,11 @@
          "prebuild:prod": "npm run clean:dist",
        "build:prod": "webpack --config config/webpack.prod.js  --progress --profile --colors --display-error-details --display-cached --bail",
 
-     "server": "npm run server:dev",
+    "github-deploy": "npm run github-deploy:dev",
+      "github-deploy:dev": "webpack --config config/webpack.github-deploy.js --progress --profile --colors --display-error-details --display-cached --github-dev",
+      "github-deploy:prod": "webpack --config config/webpack.github-deploy.js --progress --profile --colors --display-error-details --display-cached --github-prod",
+
+    "server": "npm run server:dev",
        "server:dev": "webpack-dev-server --config config/webpack.dev.js --inline --progress --profile --colors --watch --display-error-details --display-cached --content-base src/",
        "server:dev:hmr": "npm run server:dev -- --hot",
        "server:prod": "http-server dist --cors",
@@ -90,6 +94,7 @@
     "@angularclass/angular2-beta-to-rc-alias": "~0.0.3",
 
     "angular2-hmr": "~0.7.0",
+    "gh-pages": "^0.11.0",
 
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the new behavior (if this is a feature change)?**
Same as ng-cli, an option to deploy to github into the `gh-pages` branch.
This feature requires some modifications to `index.html` and an additional webpack config file `webpack.github-deploy.js`. 


* **Other information**:
Dependes on #643 
This PR adds the `gh-pages` npm packages to the devDependencies.
`gh-pages` has a lot of option to customise the operation, for this initial PR I chose to allow a limited set of configuration not to confuse.
Use can change the git remote origin and a constant commit message, see `webpack.github-deplot.js`
