### PR TITLE
docs(readme/quick-start): remove "global install" section, it's not r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ git clone --depth 1 https://github.com/angularclass/angular2-webpack-starter.git
 # change directory to our repo
 cd angular2-webpack-starter
 
-# add required global libraries
-npm install typings webpack-dev-server rimraf webpack -g
-
 # install the repo with npm
 npm install
 


### PR DESCRIPTION
Webpack, rimraf, and webpack-dev-server are all already included in package.json as devDependencies.

This means they'll be in node_modules/.bin.

npm scripts implicitly have node_modules/.bin in their path, so the npm scripts will then read from node_modules/.bin, making the global install extraneous.