### PR TITLE
bool false value not returned, Resolves issue #673

### DIFF
--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -23,7 +23,7 @@ export class AppState {
   get(prop?: any) {
     // use our state getter for the clone
     const state = this.state;
-    return state[prop] || state;
+    return state.hasOwnProperty(prop) ? state[prop] : state;
   }
 
   set(prop: string, value: any) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
resolves issue #673 


* **What is the current behavior?** (You can also link to an open issue here)
if the property is of type boolean and value false then the whole state object is returned


* **What is the new behavior (if this is a feature change)?**
the property value is returned, even if the value is false


* **Other information**:

this resolves the issue #673, that boolean properties with value 'false' are not returned.