### PR TITLE
feat(configurable-head-tags): allow configuring head tags in a js module

### DIFF
--- a/config/head-config.common.js
+++ b/config/head-config.common.js
@@ -1,0 +1,45 @@
+/**
+ * Configuration for head elements added during the creation of index.html.
+ *
+ * All href attributes are added the publicPath (if exists) by default.
+ * You can explicitly hint to prefix a publicPath by setting a boolean value to a key that has
+ * the same name as the attribute you want to operate on, but prefix with =
+ *
+ * Example:
+ * { name: "msapplication-TileImage", content: "/assets/icon/ms-icon-144x144.png", "=content": true },
+ * Will prefix the publicPath to content.
+ *
+ * { rel: "apple-touch-icon", sizes: "57x57", href: "/assets/icon/apple-icon-57x57.png", "=href": false },
+ * Will not prefix the publicPath on href (href attributes are added by default
+ *
+ */
+module.exports = {
+  link: [
+    /** <link> tags for "apple-touch-icon" (AKA Web Clips). **/
+    { rel: "apple-touch-icon", sizes: "57x57", href: "/assets/icon/apple-icon-57x57.png" },
+    { rel: "apple-touch-icon", sizes: "60x60", href: "/assets/icon/apple-icon-60x60.png" },
+    { rel: "apple-touch-icon", sizes: "72x72", href: "/assets/icon/apple-icon-72x72.png" },
+    { rel: "apple-touch-icon", sizes: "76x76", href: "/assets/icon/apple-icon-76x76.png" },
+    { rel: "apple-touch-icon", sizes: "114x114", href: "/assets/icon/apple-icon-114x114.png" },
+    { rel: "apple-touch-icon", sizes: "120x120", href: "/assets/icon/apple-icon-120x120.png" },
+    { rel: "apple-touch-icon", sizes: "144x144", href: "/assets/icon/apple-icon-144x144.png" },
+    { rel: "apple-touch-icon", sizes: "152x152", href: "/assets/icon/apple-icon-152x152.png" },
+    { rel: "apple-touch-icon", sizes: "180x180", href: "/assets/icon/apple-icon-180x180.png" },
+
+    /** <link> tags for android web app icons **/
+    { rel: "icon", type: "image/png", sizes: "192x192", href: "/assets/icon/android-icon-192x192.png" },
+
+    /** <link> tags for favicons **/
+    { rel: "icon", type: "image/png", sizes: "32x32", href: "/assets/icon/favicon-32x32.png" },
+    { rel: "icon", type: "image/png", sizes: "96x96", href: "/assets/icon/favicon-96x96.png" },
+    { rel: "icon", type: "image/png", sizes: "16x16", href: "/assets/icon/favicon-16x16.png" },
+
+    /** <link> tags for a Web App Manifest **/
+    { rel: "manifest", href: "/assets/manifest.json" }
+  ],
+  meta: [
+    { name: "msapplication-TileColor", content: "#00bcd4" },
+    { name: "msapplication-TileImage", content: "/assets/icon/ms-icon-144x144.png", "=content": true },
+    { name: "theme-color", content: "#00bcd4" }
+  ]
+};

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,7 +1,6 @@
 /**
  * @author: @AngularClass
  */
-
 var path = require('path');
 
 // Helper functions
@@ -21,7 +20,6 @@ function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [ROOT].concat(args));
 }
-
 
 exports.hasProcessFlag = hasProcessFlag;
 exports.isWebpackDevServer = isWebpackDevServer;

--- a/config/html-elements-plugin/index.js
+++ b/config/html-elements-plugin/index.js
@@ -1,0 +1,104 @@
+
+function HtmlElementsPlugin(locations) {
+  this.locations = locations;
+}
+
+HtmlElementsPlugin.prototype.apply = function(compiler) {
+  var self = this;
+  compiler.plugin('compilation', function(compilation) {
+    compilation.options.htmlElements = compilation.options.htmlElements || {};
+
+    compilation.plugin('html-webpack-plugin-before-html-generation', function(htmlPluginData, callback) {
+      const locations = self.locations;
+
+      if (locations) {
+        const publicPath = htmlPluginData.assets.publicPath;
+
+        Object.getOwnPropertyNames(locations).forEach(function(loc) {
+          compilation.options.htmlElements[loc] = getHtmlElementString(locations[loc], publicPath);
+        });
+      }
+
+
+      callback(null, htmlPluginData);
+    });
+  });
+
+};
+
+const RE_ENDS_WITH_BS = /\/$/;
+
+/**
+ * Create an HTML tag with attributes from a map.
+ *
+ * Example:
+ * createTag('link', { rel: "manifest", href: "/assets/manifest.json" })
+ * // <link rel="manifest" href="/assets/manifest.json">
+ * @param tagName The name of the tag
+ * @param attrMap A Map of attribute names (keys) and their values.
+ * @param publicPath a path to add to eh start of static asset url
+ * @returns {string}
+ */
+function createTag(tagName, attrMap, publicPath) {
+  publicPath = publicPath || '';
+
+  // add trailing slash if we have a publicPath and it doesn't have one.
+  if (publicPath && !RE_ENDS_WITH_BS.test(publicPath)) publicPath += '/';
+
+  const attributes = Object.getOwnPropertyNames(attrMap)
+    .filter(function(name) { return name[0] !== '='; } )
+    .map(function(name) {
+      var value = attrMap[name];
+
+      if (publicPath) {
+        // check if we have explicit instruction, use it if so (e.g: =herf: false)
+        // if no instruction, use public path if it's href attribute.
+        const usePublicPath = attrMap.hasOwnProperty('=' + name) ? !!attrMap['=' + name] : name === 'href';
+
+        if (usePublicPath) {
+          // remove a starting trailing slash if the value has one so we wont have //
+          value = publicPath + (value[0] === '/' ? value.substr(1) : value);
+        }
+      }
+
+      return name + '="' + value + '"';
+    });
+
+  return '<' + tagName + ' ' + attributes.join(' ') + '>';
+}
+
+/**
+ * Returns a string representing all html elements defined in a data source.
+ *
+ * Example:
+ *
+ *    const ds = {
+ *      link: [
+ *        { rel: "apple-touch-icon", sizes: "57x57", href: "/assets/icon/apple-icon-57x57.png" }
+ *      ],
+ *      meta: [
+ *        { name: "msapplication-TileColor", content: "#00bcd4" }
+ *      ]
+ *    }
+ *
+ * getHeadTags(ds);
+ * // "<link rel="apple-touch-icon" sizes="57x57" href="/assets/icon/apple-icon-57x57.png">"
+ *    "<meta name="msapplication-TileColor" content="#00bcd4">"
+ *
+ * @returns {string}
+ */
+function getHtmlElementString(dataSource, publicPath) {
+  return Object.getOwnPropertyNames(dataSource)
+    .map(function(name) {
+      if (Array.isArray(dataSource[name])) {
+        return dataSource[name].map(function(attrs) { return createTag(name, attrs, publicPath); } );
+      } else {
+        return [ createTag(name, dataSource[name], publicPath) ];
+      }
+    })
+    .reduce(function(arr, curr) {
+      return arr.concat(curr);
+    }, [])
+    .join('\n\t');
+}
+module.exports = HtmlElementsPlugin;

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -12,6 +12,7 @@ const helpers = require('./helpers');
 var CopyWebpackPlugin = (CopyWebpackPlugin = require('copy-webpack-plugin'), CopyWebpackPlugin.default || CopyWebpackPlugin);
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ForkCheckerPlugin = require('awesome-typescript-loader').ForkCheckerPlugin;
+const HtmlElementsPlugin = require('./html-elements-plugin');
 
 /*
  * Webpack Constants
@@ -243,8 +244,33 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'src/index.html',
       chunksSortMode: 'dependency'
-    })
+    }),
 
+    /*
+     * Plugin: HtmlHeadConfigPlugin
+     * Description: Generate html tags based on javascript maps.
+     *
+     * If a publicPath is set in the webpack output configuration, it will be automatically added to
+     * href attributes, you can disable that by adding a "=href": false property.
+     * You can also enable it to other attribute by settings "=attName": true.
+     *
+     * The configuration supplied is map between a location (key) and an element definition object (value)
+     * The location (key) is then exported to the template under then htmlElements property in webpack configuration.
+     *
+     * Example:
+     *  Adding this plugin configuration
+     *  new HtmlElementsPlugin({
+     *    headTags: { ... }
+     *  })
+     *
+     *  Means we can use it in the template like this:
+     *  <%= webpackConfig.htmlElements.headTags %>
+     *
+     * Dependencies: HtmlWebpackPlugin
+     */
+    new HtmlElementsPlugin({
+      headTags: require('./head-config.common')
+    })
   ],
 
   /*

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
 
   <% if (webpackConfig.htmlElements.headTags) { %>
   <!-- Configured Head Tags  -->
-  <%=webpackConfig.htmlElements.headTags%>
+  <%= webpackConfig.htmlElements.headTags %>
   <% } %>
 
   <!-- base url -->

--- a/src/index.html
+++ b/src/index.html
@@ -9,25 +9,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="<%= webpackConfig.metadata.title %>">
 
-  <!-- use http://www.favicon-generator.org/ to replace files in public/icon-->
-  <link rel="apple-touch-icon" sizes="57x57" href="/assets/icon/apple-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="/assets/icon/apple-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="/assets/icon/apple-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="/assets/icon/apple-icon-76x76.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="/assets/icon/apple-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="/assets/icon/apple-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="/assets/icon/apple-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/assets/icon/apple-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icon/apple-icon-180x180.png">
-  <link rel="icon" type="image/png" sizes="192x192"  href="/assets/icon/android-icon-192x192.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icon/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="96x96" href="/assets/icon/favicon-96x96.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/icon/favicon-16x16.png">
-  <link rel="manifest" href="/assets/manifest.json">
-  <meta name="msapplication-TileColor" content="#00bcd4">
-  <meta name="msapplication-TileImage" content="/assets/icon/ms-icon-144x144.png">
-  <meta name="theme-color" content="#00bcd4">
-  <!-- end favicon -->
+  <% if (webpackConfig.htmlElements.headTags) { %>
+  <!-- Configured Head Tags  -->
+  <%=webpackConfig.htmlElements.headTags%>
+  <% } %>
 
   <!-- base url -->
   <base href="<%= webpackConfig.metadata.baseUrl %>">


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
head tags are hardcoded in `index.html` (specially assets


* **What is the new behavior (if this is a feature change)?**
head tags are created dynamically from a JS module.


* **Other information**:
This behavior also cleans up the index.html file.
A step for `github` pages support #645