### PR TITLE
fix globbing problems on tslint, on osx wouldn't correctly glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
      "webdriver:update": "npm run webdriver-manager update",
      "webdriver:start": "npm run webdriver-manager start",
 
-     "lint": "npm run tslint src/**/*.ts",
+     "lint": "npm run tslint \"src/**/*.ts\"",
 
        "pree2e": "npm run webdriver:update -- --standalone",
      "e2e": "npm run protractor",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

FIX globbing of ts files on osx

* **What is the current behavior?** (You can also link to an open issue here)

Will not go deeper than 2 levels

* **What is the new behavior (if this is a feature change)?**

Will scan all the files

* **Other information**:

