### PR TITLE
docs(readme): fix typings install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install
 
 # WINDOWS ONLY
 # install typings
-npm run typings-install
+npm run typings install
 
 # start the server
 npm start


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Simple readme fix, to a command that works.

* **What is the current behavior?** (You can also link to an open issue here)

`npm run typings-install` yields:

> npm ERR! missing script: typings-install

* **What is the new behavior (if this is a feature change)?**

Typings will be installed correctly.

* **Other information**:

...since there's no `typings-install` script @ package.json.