### PR TITLE
use typescript declarations for es2015

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,13 @@
     "baseUrl": "./src",
     "paths": [
     ],
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.promise",
+      "es2015.collection"
+    ],
     "types": [
-      "core-js",
       "hammerjs",
       "jasmine",
       "node",


### PR DESCRIPTION
Since Typescript2 its possible to use es2015 declarations with `target: es5` specified.
And we can drop `@types/core-js` from deps.

See: https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#including-built-in-type-declarations-with---lib