### PR TITLE
Update webpack.dev.js to take respect optional HOST/PORT params

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -15,10 +15,12 @@ const DefinePlugin = require('webpack/lib/DefinePlugin');
  * Webpack Constants
  */
 const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
+const HOST = process.env.HOST || 'localhost';
+const PORT = process.env.PORT || 3000;
 const HMR = helpers.hasProcessFlag('hot');
 const METADATA = webpackMerge(commonConfig.metadata, {
-  host: 'localhost',
-  port: 3000,
+  host: HOST,
+  port: PORT,
   ENV: ENV,
   HMR: HMR
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enhancement

* **What is the current behavior?** (You can also link to an open issue here)

Production configuration lets you configure host and port, but dev configuration does not. It defaults to localhost and port 3000.

Fixes issue:
https://github.com/AngularClass/angular2-webpack-starter/issues/821
And partially:
https://github.com/AngularClass/angular2-webpack-starter/issues/186


* **What is the new behavior (if this is a feature change)?**

Now to run dev server on a VM you can just run
PORT=8081 HOST="0.0.0.0" npm run server:dev:hmr
or if you're using "forever"
PORT=8081 HOST="0.0.0.0" forever start -v --minUptime 1000 --spinSleepTime 1000 -c "npm run server:dev:hmr" ./


* **Other information**:

I'm using this to setup an automated Vagrant setup, and this way I can make all the changes in scripts instead of by hand. This also brings the dev config closer to the prod config.