### PR TITLE
Update webpack.common.js

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -173,8 +173,14 @@ module.exports = {
         test: /\.html$/,
         loader: 'raw-loader',
         exclude: [helpers.root('src/index.html')]
+      },
+      
+      /* File loader for supporting images, for example, in CSS files.
+      */
+      {
+        test: /\.(jpg|png|gif)$/,
+        loader: 'file'
       }
-
     ]
 
   },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Currently, when a background url(...) statement is used in CSS, webpack tries to incorrectly process the file reference as javascript. This causes a build error.

* **What is the new behavior (if this is a feature change)?**

Adding a file-loader to handle jpg/png/gif files fixes this.

* **Other information**:

Added use of file-loader for jpg/png/gif files. This adds support for using background url() statements in CSS files, as per https://github.com/AngularClass/angular2-webpack-starter/issues/759