### PR TITLE
Fix { TestComponentBuilder } for latest @Angular RC5

### DIFF
--- a/src/app/about/about.spec.ts
+++ b/src/app/about/about.spec.ts
@@ -1,4 +1,4 @@
-import { TestComponentBuilder } from '@angular/compiler/testing';
+import { TestComponentBuilder } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import {

--- a/src/app/home/title/title.spec.ts
+++ b/src/app/home/title/title.spec.ts
@@ -2,7 +2,7 @@ import {
   addProviders,
   inject
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
+import { TestComponentBuilder } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';

--- a/src/app/home/x-large/x-large.spec.ts
+++ b/src/app/home/x-large/x-large.spec.ts
@@ -3,7 +3,7 @@ import {
   addProviders,
   inject
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
+import { TestComponentBuilder } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** : Bug fix

* **What is the current behavior?**
When running tests you get errors like:
```
ERROR in [default] ...GitHub/_forks/angular2-webpack-starter/src/app/about/about.spec.ts:1:9
Module '"C:/Users/azureuser/Documents/GitHub/_forks/angular2-webpack-starter/node_modules/@angular/compiler/testing"' has no exported member 'TestComponentBuilder'.
```

* **What is the new behavior (if this is a feature change)?**
No errors.