### PR TITLE
Add missing type information to compile in case of `noImplicitAny`

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -128,9 +128,9 @@ module.exports = {
       {
         test: /\.ts$/,
         loaders: [
+          '@angularclass/hmr-loader',
           'awesome-typescript-loader',
-          'angular2-template-loader',
-          '@angularclass/hmr-loader'
+          'angular2-template-loader'
         ],
         exclude: [/\.(spec|e2e)\.ts$/]
       },

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -27,7 +27,7 @@ console.log('`About` component loaded asynchronously');
   `
 })
 export class About {
-  localState;
+  localState: any;
   constructor(public route: ActivatedRoute) {
 
   }

--- a/src/app/about/about.spec.ts
+++ b/src/app/about/about.spec.ts
@@ -1,4 +1,4 @@
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Data } from '@angular/router';
 import { Component } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 
@@ -14,7 +14,7 @@ describe('About', () => {
         provide: ActivatedRoute,
         useValue: {
           data: {
-            subscribe: (fn) => fn({
+            subscribe: (fn: (value: Data) => void) => fn({
               yourData: 'yolo'
             })
           }
@@ -24,7 +24,7 @@ describe('About', () => {
     ]
   }));
 
-  it('should log ngOnInit', inject([About], (about) => {
+  it('should log ngOnInit', inject([About], (about: About) => {
     spyOn(console, 'log');
     expect(console.log).not.toHaveBeenCalled();
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { ROUTES } from './app.routes';
 // App is our top level component
 import { App } from './app.component';
 import { APP_RESOLVER_PROVIDERS } from './app.resolver';
-import { AppState } from './app.service';
+import { AppState, InteralStateType } from './app.service';
 import { Home } from './home';
 import { About } from './about';
 import { NoContent } from './no-content';
@@ -24,6 +24,11 @@ const APP_PROVIDERS = [
   ...APP_RESOLVER_PROVIDERS,
   AppState
 ];
+
+type StoreType = {
+  state: InteralStateType,
+  disposeOldHosts: () => void
+};
 
 /**
  * `AppModule` is the main entry point into Angular2's bootstraping process
@@ -50,14 +55,14 @@ const APP_PROVIDERS = [
 })
 export class AppModule {
   constructor(public appRef: ApplicationRef, public appState: AppState) {}
-  hmrOnInit(store) {
+  hmrOnInit(store: StoreType) {
     if (!store || !store.state) return;
     console.log('HMR store', store);
     this.appState._state = store.state;
     this.appRef.tick();
     delete store.state;
   }
-  hmrOnDestroy(store) {
+  hmrOnDestroy(store: StoreType) {
     const cmpLocation = this.appRef.components.map(cmp => cmp.location.nativeElement);
     // recreate elements
     const state = this.appState._state;
@@ -66,7 +71,7 @@ export class AppModule {
     // remove styles
     removeNgStyles();
   }
-  hmrAfterDestroy(store) {
+  hmrAfterDestroy(store: StoreType) {
     // display new elements
     store.disposeOldHosts();
     delete store.disposeOldHosts;

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -1,8 +1,12 @@
 import { Injectable } from '@angular/core';
 
+export type InteralStateType = {
+  [key: string]: any
+};
+
 @Injectable()
 export class AppState {
-  _state = { };
+  _state: InteralStateType = { };
 
   constructor() {
 
@@ -30,7 +34,7 @@ export class AppState {
   }
 
 
-  _clone(object) {
+  private _clone(object: InteralStateType) {
     // simple object clone
     return JSON.parse(JSON.stringify( object ));
   }

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -15,7 +15,7 @@ describe('App', () => {
       App
     ]}));
 
-  it('should have a url', inject([ App ], (app) => {
+  it('should have a url', inject([ App ], (app: App) => {
     expect(app.url).toEqual('https://twitter.com/AngularClass');
   }));
 

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -4,13 +4,13 @@
 import { enableDebugTools, disableDebugTools } from '@angular/platform-browser';
 import { enableProdMode, ApplicationRef } from '@angular/core';
 // Environment Providers
-let PROVIDERS = [
+let PROVIDERS: any[] = [
   // common env directives
 ];
 
 // Angular debug tools in the dev console
 // https://github.com/angular/angular/blob/86405345b781a9dc2438c0fbe3e9409245647019/TOOLS_JS.md
-let _decorateModuleRef = function identity(value) { return value; };
+let _decorateModuleRef = function identity<T>(value: T): T { return value; };
 
 if ('production' === ENV) {
   // Production

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -31,7 +31,7 @@ export class Home {
     // this.title.getData().subscribe(data => this.data = data);
   }
 
-  submitState(value) {
+  submitState(value: string) {
     console.log('submitState', value);
     this.appState.set('value', value);
     this.localState.value = '';

--- a/src/app/home/home.spec.ts
+++ b/src/app/home/home.spec.ts
@@ -34,15 +34,15 @@ describe('Home', () => {
     ]
   }));
 
-  it('should have default data', inject([ Home ], (home) => {
+  it('should have default data', inject([ Home ], (home: Home) => {
     expect(home.localState).toEqual({ value: '' });
   }));
 
-  it('should have a title', inject([ Home ], (home) => {
+  it('should have a title', inject([ Home ], (home: Home) => {
     expect(!!home.title).toEqual(true);
   }));
 
-  it('should log ngOnInit', inject([ Home ], (home) => {
+  it('should log ngOnInit', inject([ Home ], (home: Home) => {
     spyOn(console, 'log');
     expect(console.log).not.toHaveBeenCalled();
 

--- a/src/app/home/title/title.spec.ts
+++ b/src/app/home/title/title.spec.ts
@@ -27,11 +27,11 @@ describe('Title', () => {
       Title
     ]}));
 
-  it('should have http', inject([ Title ], (title) => {
+  it('should have http', inject([ Title ], (title: Title) => {
     expect(!!title.http).toEqual(true);
   }));
 
-  it('should get data from the server', inject([ Title ], (title) => {
+  it('should get data from the server', inject([ Title ], (title: Title) => {
     spyOn(console, 'log');
     expect(console.log).not.toHaveBeenCalled();
 

--- a/src/custom-typings.d.ts
+++ b/src/custom-typings.d.ts
@@ -56,8 +56,8 @@ interface SystemJS {
 }
 
 interface GlobalEnvironment {
-  ENV;
-  HMR;
+  ENV: string;
+  HMR: boolean;
   SystemJS: SystemJS;
   System: SystemJS;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Added missing type information to compile in case of `noImplicitAny` is set to true

* **What is the current behavior?** (You can also link to an open issue here)

If you set `noImplicitAny` to true, you have many TypeScript errors.

* **What is the new behavior (if this is a feature change)?**

Compiled without errors when `noImplicitAny` is set to true.

* **Other information**:

See https://github.com/angular/angular-cli/issues/107#issuecomment-164809092