### PR TITLE
Replace obsolete setBaseTestProviders with TestBed.initTestEnvironment

### DIFF
--- a/config/spec-bundle.js
+++ b/config/spec-bundle.js
@@ -33,9 +33,9 @@ require('rxjs/Rx');
 var testing = require('@angular/core/testing');
 var browser = require('@angular/platform-browser-dynamic/testing');
 
-testing.setBaseTestProviders(
-  browser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
-  browser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS
+testing.TestBed.initTestEnvironment(
+  browser.BrowserDynamicTestingModule,
+  browser.platformBrowserDynamicTesting()
 );
 
 /*


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (fix)

Since `Angular RC.5` testing API [has changed](https://github.com/angular/angular/commit/fa47890). This PR replaces obsolete `setBaseTestProviders` with `TestBed.initTestEnvironment`

