### PR TITLE
isWebpackDevServer() fix for windows, issue #757

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -11,7 +11,7 @@ function hasProcessFlag(flag) {
 }
 
 function isWebpackDevServer() {
-  return process.argv[1] && !! (/webpack-dev-server$/.exec(process.argv[1]));
+  return process.argv[1] && !! (/webpack-dev-server/.exec(process.argv[1]));
 }
 
 function root(args) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It's should fix issue #757

* **What is the current behavior?** (You can also link to an open issue here)
Like described in issue #757


* **What is the new behavior (if this is a feature change)?**
Exec will return to ["webpack-dev-server"] in case if we run webpack-dev-server
example:
/webpack-dev-server/.exec('D:\angular2-webpack-starter\node_modules\webpack-dev-server\bin\webpack-dev-server.js')  //return  ["webpack-dev-server"] ,

so whole expression will be like:
function isWebpackDevServer() {
'D:\angular2-webpack-starter\node_modules\webpack-dev-server\bin\webpack-dev-server.js' && !!["webpack-dev-server"]
}
what is true;
* **Other information**:

