### PR TITLE
Set karma-webpack to only log errors

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -46,7 +46,7 @@ module.exports = function(config) {
     },
 
     // Webpack please don't spam the console when running in karma!
-    webpackServer: { noInfo: true },
+    webpackMiddleware: { stats: 'errors-only'},
 
     /*
      * test results reporter to use


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Not sure when the api changed, but `webpackServer: { noInfo: true },` doesn't work anymore. This uses 
`webpackMiddleware: { stats: 'errors-only'}` to accomplish the same goal.

* **What is the current behavior?** (You can also link to an open issue here)

When running tests, built modules are output to the console.

* **What is the new behavior (if this is a feature change)?**

Karma-webpack will only output errors during code compile for tests.



* **Other information**:

Set wepack to only output errors during testing