### PR TITLE
Update string-replace-loader to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "remap-istanbul": "^0.6.3",
     "rimraf": "^2.5.2",
     "source-map-loader": "^0.1.5",
-    "string-replace-loader": "github:gdi2290/string-replace-loader",
+    "string-replace-loader": "1.0.5",
     "style-loader": "^0.13.1",
     "to-string-loader": "^1.1.4",
     "ts-helpers": "1.1.1",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

**Dependency update**

This removes the need for forked version of  string-replace-loader

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:

