### PR TITLE
Fix issue #1035

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/jasmine": "^2.2.29",
     "@types/node": "^6.0.38",
     "@types/protractor": "^1.5.16",
-    "@types/selenium-webdriver": "^2.44.26",
+    "@types/selenium-webdriver": "2.44.29",
     "@types/source-map": "^0.1.26",
     "@types/uglify-js": "^2.0.27",
     "@types/webpack": "^1.12.29",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
If you run 'npm run build:prod' it fails with this error:
```
...
 94% asset optimizationError in bail mode: [default] /Users/smith/Git/webpack-starter-test/node_modules/@types/protractor/index.d.ts:22:26
Module 'webdriver' has no exported member 'IButton'.
...
```

The reason is the new version of @types/selenium-webdriver (2.53.30)

* **What is the new behavior (if this is a feature change)?**
With the previous version of @types/selenium-webdriver it works.


* **Other information**:

https://github.com/AngularClass/angular2-webpack-starter/issues/1035