### PR TITLE
removed ignored property density from manifest.json

### DIFF
--- a/src/assets/manifest.json
+++ b/src/assets/manifest.json
@@ -4,38 +4,32 @@
   {
    "src": "/assets/icon/android-icon-36x36.png",
    "sizes": "36x36",
-   "type": "image/png",
-   "density": 0.75
+   "type": "image/png"
   },
   {
    "src": "/assets/icon/android-icon-48x48.png",
    "sizes": "48x48",
-   "type": "image/png",
-   "density": 1.0
+   "type": "image/png"
   },
   {
    "src": "/assets/icon/android-icon-72x72.png",
    "sizes": "72x72",
-   "type": "image/png",
-   "density": 1.5
+   "type": "image/png"
   },
   {
    "src": "/assets/icon/android-icon-96x96.png",
    "sizes": "96x96",
-   "type": "image/png",
-   "density": 2.0
+   "type": "image/png"
   },
   {
    "src": "/assets/icon/android-icon-144x144.png",
    "sizes": "144x144",
-   "type": "image/png",
-   "density": 3.0
+   "type": "image/png"
   },
   {
    "src": "/assets/icon/android-icon-192x192.png",
    "sizes": "192x192",
-   "type": "image/png",
-   "density": 4.0
+   "type": "image/png"
   }
  ]
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
removed ignored `density` attribute from manifest.json


* **What is the current behavior?** (You can also link to an open issue here)
ignored attribute `density` is present in `manifest.json`


* **What is the new behavior (if this is a feature change)?**
attribute `density` is removed from manifest.json


* **Other information**:
According to [Google](https://developers.google.com/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android), `density` will be ignored from manifest.json:

> Please note, there used to be a dedicated “density” field in the manifest spec, this has been removed from the Spec and the implementation in Chrome. If it is defined in your manifest it will be ignored.  

Also, there is no information about `density` in the [spec](https://w3c.github.io/manifest/).