### PR TITLE
Update tsconfig.json paths property to object

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "noEmitHelpers": true,
     "strictNullChecks": false,
     "baseUrl": "./src",
-    "paths": [
-    ],
+    "paths": {
+    },
     "lib": [
       "dom",
       "es6"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A **configuration file change.**
This change is merely change in tsconfig from an empty array to an empty object to conform with proper tsconfig compiler options. Just to remove type error warnings in coding programs.

* **What is the current behavior?** (You can also link to an open issue here)

Currently the code is `paths: []`

* **What is the new behavior (if this is a feature change)?**

Proposing a change to `paths: {}`

* **Other information**:

In the tsconfig.json the property `compilerOptions.paths` should be an object and not an array.

See https://www.typescriptlang.org/docs/handbook/compiler-options.html