### PR TITLE
Copy humans.txt and robots.txt to dist/

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -244,6 +244,16 @@ module.exports = function(options) {
       new CopyWebpackPlugin([{
         from: 'src/assets',
         to: 'assets'
+      }], {
+        ignore: [
+          'humans.txt',
+          'robots.txt'
+        ]
+      }),
+      new CopyWebpackPlugin([{ 
+        from: 'src/assets/robots.txt'
+      }, { 
+        from: 'src/assets/humans.txt' 
       }]),
 
       /*


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#1070 humans.txt and robots.txt get copied from the assets directory to the output assets directory.


* **What is the new behavior (if this is a feature change)?**
All files in the assets folder get copied to dist/assets except for humans.txt and robots.txt.
humans.txt and robots.txt get copied from the assets folder to the root dist/ folder.


* **Other information**:

Fixes issue #1070

The standard for humans.txt and robots.txt says that they should be available from the root of the application. This change will make sure that they get copied from the assets folder to the dist/ root instead of to dist/assets.