### PR TITLE
Remove unsed dependencies: webpack-toolkit, request-idle-callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,6 @@
     "@angularclass/conventions-loader": "^1.0.2",
     "@angularclass/hmr": "~1.2.0",
     "@angularclass/hmr-loader": "~3.0.2",
-    "@angularclass/request-idle-callback": "^1.0.7",
-    "@angularclass/webpack-toolkit": "^1.3.3",
     "assets-webpack-plugin": "^3.4.0",
     "core-js": "^2.4.1",
     "http-server": "^0.9.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Remove unused dependencies from package.json

``@angularclass/webpack-toolkit``
``@angularclass/request-idle-callback``

Are these still used? Can't find any reference to it in the current version.


* **What is the current behavior?** (You can also link to an open issue here)

dependencies in

* **What is the new behavior (if this is a feature change)?**

dependencies out

* **Other information**:

