### PR TITLE
Remove warning about Angular 2 is not ready yet.

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,6 @@
 <li>Test and end-to-end system using Karma and Protractor.</li>
 </ul>
 
-<div class="highlight highlight-source-coffee"><pre><span class="pl-v"><span class="pl-v">Warning:</span></span> <span class="pl-en">Angular </span><span class="pl-c1">2.0</span> <span class="pl-k">is</span> <span class="pl-k">not</span> <span class="pl-en">production ready </span>yet<span class="pl-k">!</span></pre></div>
-
-<p><a href="http://splintercode.github.io/is-angular-2-ready/">Is Angular 2 Ready Yet?</a></p>
-
 <h3>
 <a id="quick-start" class="anchor" href="#quick-start" aria-hidden="true"><span class="octicon octicon-link"></span></a>Quick start</h3>
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

docs update

* **What is the current behavior?** (You can also link to an open issue here)

Showing warning that Angular 2 is not ready.

* **What is the new behavior (if this is a feature change)?**

Doesn't show the warning about Angular 2 is not ready.

* **Other information**:

Removed a warning and link to [Is Angular 2 Ready?](https://splintercode.github.io/is-angular-2-ready/).