### PR TITLE
ci(travis): Enable e2e test execution in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ node_js:
 services:
   - docker
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   # Repo for yarn
   - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
@@ -20,8 +17,16 @@ before_install:
   - npm i -g npm@^3
 install:
   - yarn
+before_script:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3
+  - npm start &
+  - sleep 5
 script:
   - npm test
+  - npm run e2e
   - npm run build:docker
 cache:
   directories:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  CI Changes
- **What is the current behavior?** (You can also link to an open issue here)
  Travis executes Karma Spec test only
- **What is the new behavior (if this is a feature change)?**
  - Webpack is spun up in a forked process
  - Karma test run as usual
  - Protractor e2e Tests are executed prior to the Docker build
- **Other information**:

Resolves #1113
