### PR TITLE
Close script tags in html-elements-plugin

### DIFF
--- a/config/html-elements-plugin/index.js
+++ b/config/html-elements-plugin/index.js
@@ -63,12 +63,12 @@ function createTag(tagName, attrMap, publicPath) {
         }
       }
 
-      return name + '="' + value + '"';
+      return `${name}="${value}"`;
     });
 
   const closingTag = tagName === 'script' ? '</script>' : '';
 
-  return '<' + tagName + ' ' + attributes.join(' ') + '>' + closingTag;
+  return `<${tagName} ${attributes.join(' ')}>${closingTag}`;
 }
 
 /**

--- a/config/html-elements-plugin/index.js
+++ b/config/html-elements-plugin/index.js
@@ -66,7 +66,9 @@ function createTag(tagName, attrMap, publicPath) {
       return name + '="' + value + '"';
     });
 
-  return '<' + tagName + ' ' + attributes.join(' ') + '>';
+  const closingTag = tagName === 'script' ? '</script>' : '';
+
+  return '<' + tagName + ' ' + attributes.join(' ') + '>' + closingTag;
 }
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Script tags are not properly closed when included in the html-elements-plugin

* **What is the new behavior (if this is a feature change)?**

Script tags are now properly closed

* **Other information**:

My solution is a bit messy and I'm not sure whether or not the original behavior was intended. Anyways this was useful for me since I wanted to include a library from a CDN and have it in the same configuration file as the CSS and fonts loaded from CDNs.

