### PR TITLE
fix(angular2.2): wait for angular before disabling debug info

### DIFF
--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -14,8 +14,12 @@ let _decorateModuleRef = function identity<T>(value: T): T { return value; };
 
 if ('production' === ENV) {
   // Production
-  disableDebugTools();
-  enableProdMode();
+  _decorateModuleRef = (modRef: any) => {
+    disableDebugTools();
+    enableProdMode();
+    
+    return modRef;
+  };
 
   PROVIDERS = [
     ...PROVIDERS,

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -13,10 +13,11 @@ let PROVIDERS: any[] = [
 let _decorateModuleRef = function identity<T>(value: T): T { return value; };
 
 if ('production' === ENV) {
+  enableProdMode();
+  
   // Production
   _decorateModuleRef = (modRef: any) => {
     disableDebugTools();
-    enableProdMode();
     
     return modRef;
   };
@@ -27,7 +28,7 @@ if ('production' === ENV) {
   ];
 
 } else {
-
+  
   _decorateModuleRef = (modRef: any) => {
     const appRef = modRef.injector.get(ApplicationRef);
     const cmpRef = appRef.components[0];

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -14,11 +14,11 @@ let _decorateModuleRef = function identity<T>(value: T): T { return value; };
 
 if ('production' === ENV) {
   enableProdMode();
-  
+
   // Production
   _decorateModuleRef = (modRef: any) => {
     disableDebugTools();
-    
+
     return modRef;
   };
 
@@ -28,7 +28,7 @@ if ('production' === ENV) {
   ];
 
 } else {
-  
+
   _decorateModuleRef = (modRef: any) => {
     const appRef = modRef.injector.get(ApplicationRef);
     const cmpRef = appRef.components[0];


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix a bug that appears with Angular2.2 when using a production bundle.

* **What is the current behavior?** (You can also link to an open issue here)
Currently, when launching a prod bundle, the app doesn't work because of an `Cannot convert undefined or null to Object` that occurs in the `disableDebugInfo` function of Angular2.2.
This function tries to delete `window.ng.provider`, but at the moment of the call of the `disabledDebugInfo` function, the `ng` property has not yet been created in the `window` object because Angular is not yet initialized.

* **What is the new behavior (if this is a feature change)?**
We now wait for Angular to be initialized before disabling debug info and enabling production mode.
This way, the `disableDebugInfo` call succeed and the app doesn't crash anymore.

* **Other information**: