### PR TITLE
Updated typedoc to v0.5.1 including support for typescript 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "ts-node": "^1.7.0",
     "tslint": "~3.15.1",
     "tslint-loader": "^2.1.5",
-    "typedoc": "^0.5.0",
+    "typedoc": "^0.5.1",
     "typescript": "^2.0.6",
     "url-loader": "^0.5.7",
     "v8-lazy-parse-webpack-plugin": "^0.3.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Added support for typescript2 to typedoc

* **What is the current behavior?** (You can also link to an open issue here)

typedoc is not generating any docs

* **What is the new behavior (if this is a feature change)?**

docs are generated even if there are some warnings

* **Other information**:

