### PR TITLE
chore(yarn): add yarn files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ Thumbs.db
 /bower_components
 npm-debug.log
 
+# Yarn #
+yarn.lock
+yarn-debug.log
+
 # Coverage #
 /coverage/
 


### PR DESCRIPTION
* **What is the new behavior (if this is a feature change)?**
Ignores yarn output 


* **Other information**:

Per https://github.com/AngularClass/angular2-webpack-starter/commit/5db20a697bee643758ce597c8b9f7059f398e462#commitcomment-20016692