### PR TITLE
added sourcemap in production build

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -150,7 +150,7 @@ module.exports = function (env) {
         // }, // debug
         // comments: true, //debug
 
-
+        sourceMap:true,
         beautify: false, //prod
         output: {
           comments: false


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix, uglify does not generate sourcemap in production build.


* **What is the current behavior?** (You can also link to an open issue here)
in production build only js bundle is generated.


* **What is the new behavior (if this is a feature change)?**
js bundle and sourcemaps is generated.


* **Other information**:

added sourcemap in production build