### PR TITLE
chore(package): pins TypeScript version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ts-helpers": "1.1.2",
     "ts-node": "^1.7.0",
     "tslint": "~3.15.1",
-    "tslint-loader": "^3.3.0",
+    "tslint-loader": "^2.1.5",
     "typedoc": "^0.5.0",
     "typescript": "2.1.1",
     "url-loader": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "tslint": "~3.15.1",
     "tslint-loader": "^3.3.0",
     "typedoc": "^0.5.0",
-    "typescript": "^2.0.6",
+    "typescript": "2.1.1",
     "url-loader": "^0.5.7",
     "v8-lazy-parse-webpack-plugin": "^0.3.0",
     "webpack": "2.1.0-beta.27",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore - Work around for `awesome-typescript-loader` issue.


- Relavent issue: https://github.com/s-panferov/awesome-typescript-loader/issues/293

Relates to #1249