### PR TITLE
refactor sourceMapFilename to use file

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -71,7 +71,7 @@ module.exports = function (options) {
        *
        * See: http://webpack.github.io/docs/configuration.html#output-sourcemapfilename
        */
-      sourceMapFilename: '[name].map',
+      sourceMapFilename: '[file].map',
 
       /** The filename of non-entry chunks as relative path
        * inside the output.path directory.


### PR DESCRIPTION
It's correcting to use [file] instead [name] in order to support work together with ExtractTextPlugin souremaps

Inspired by:
https://github.com/webpack/extract-text-webpack-plugin/issues/119#issuecomment-181584004