### PR TITLE
Fix code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.0.2",
     "karma-mocha-reporter": "^2.0.0",
-    "karma-remap-coverage": "^0.1.1",
+    "karma-remap-coverage": "0.1.1",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "1.8.0",
     "parse5": "^2.2.2",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Latest version of karma-remap-coverage cause following error:

```
19 12 2016 13:30:40.344:ERROR [coverage]: TypeError: remap is not a function
    at RemapCoverageReporter.onCoverageComplete (/node_modules/karma-remap-coverage/remap-coverage.js:23:23)
    at Server.<anonymous> (/node_modules/karma/lib/events.js:13:22)
    at emitTwo (events.js:106:13)
    at Server.emit (events.js:191:7)
    at InMemoryReport.writeReport (/node_modules/karma-coverage/lib/in-memory-report.js:14:22)
    at writeReport (/node_modules/karma-coverage/lib/reporter.js:68:16)
    at /node_modules/karma-coverage/lib/reporter.js:290:11
    at Array.forEach (native)
    at Collection.forEach (/node_modules/karma/lib/browser_collection.js:93:21)
    at /node_modules/karma-coverage/lib/reporter.js:247:16
    at Array.forEach (native)
    at CoverageReporter.onRunComplete (/node_modules/karma-coverage/lib/reporter.js:246:15)
    at Server.<anonymous> (/node_modules/karma/lib/events.js:13:22)
    at emitTwo (events.js:111:20)
    at Server.emit (events.js:191:7)
    at emitRunCompleteIfAllBrowsersDone (/node_modules/karma/lib/server.js:294:12)
```

* **What is the new behavior (if this is a feature change)?**

Comes back to the latest stable behavior. 

* **Other information**:
