### PR TITLE
Update Material2 Project URL

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -2,7 +2,7 @@
   <h1 x-large class="sample-content">Your Content Here</h1>
 
   <div>
-    For material design components use the <a href="https://github.com/AngularClass/angular2-webpack-starter/tree/material2"><b>material2</b></a> branch
+    For material design components use the <a href="https://github.com/angular/material2"><b>material2</b></a> branch
   </div>
 
   <hr>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

docs update.

* **What is the current behavior?** (You can also link to an open issue here)

 material2 link error. page not found.

* **What is the new behavior (if this is a feature change)?**

change link with https://github.com/angular/material2

* **Other information**: