### PR TITLE
(fix) enable sourcemaps in production build

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -171,6 +171,7 @@ module.exports = function (env) {
           join_vars: true,
           negate_iife: false // we need this for lazy v8
         },
+        sourceMap: true
       }),
 
       /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: sourcemaps are no longer enabled by default in the UglifyJS Webpack plugin.


* **What is the current behavior?** (You can also link to an open issue here)
No source maps are generated in a production build.


* **What is the new behavior (if this is a feature change)?**
Source maps are correctly generated.


* **Other information**:
