### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ ___
 > If you're looking to learn about Webpack and ES6 Build Tools check out [ES6-build-tools](https://github.com/AngularClass/ES6-build-tools)
 > If you're looking to learn TypeScript see [TypeStrong/learn-typescript](https://github.com/TypeStrong/learn-typescript)
 > If you're looking for something easier to get started with then see the angular2-seed that I also maintain [angular/angular2-seed](https://github.com/AngularClass/angular2-seed)
-> If you're looking to add Angular 2 Material Design we have a branch [material2](https://github.com/AngularClass/angular2-webpack-starter/tree/material2)
 
 This seed repo serves as an Angular 2 starter for anyone looking to get up and running with Angular 2 and TypeScript fast. Using a [Webpack 2](http://webpack.github.io/) for building our files and assisting with boilerplate. We're also using Protractor for our end-to-end story and Karma for our unit tests.
 * Best practices in file and application organization for Angular 2.

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,10 +1,6 @@
 <div class="card-container">
   <h1 x-large class="sample-content">Your Content Here</h1>
 
-  <div>
-    For material design components use the <a href="https://github.com/AngularClass/angular2-webpack-starter/tree/material2"><b>material2</b></a> branch
-  </div>
-
   <hr>
 
   <div>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


* **What is the current behavior?** (You can also link to an open issue here)
Two links point to an old [material2 branch](https://github.com/AngularClass/angular2-webpack-starter/tree/material2) which no longer exists, so both links are broken.


* **What is the new behavior (if this is a feature change)?**
Broken links to nonexistent branch "material2" are removed.


* **Other information**:
N/A