### PR TITLE
Update tsconfig.webpack.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,6 @@
     "noEmit": true,
     "noEmitHelpers": true,
     "strictNullChecks": false,
-    "baseUrl": "./src",
-    "paths": {
-    },
     "lib": [
       "dom",
       "es6"
@@ -37,5 +34,7 @@
   },
   "compileOnSave": false,
   "buildOnSave": false,
-  "atom": { "rewriteTsconfig": false }
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "noEmitHelpers": true,
     "strictNullChecks": false,
-    "baseUrl": "./src",
+    "baseUrl": "./node_modules",
     "paths": {
     },
     "lib": [

--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -10,9 +10,6 @@
     "noEmit": true,
     "noEmitHelpers": true,
     "strictNullChecks": false,
-    "baseUrl": "./node_modules",
-    "paths": {
-    },
     "lib": [
       "es2015",
       "dom"
@@ -33,10 +30,12 @@
     "useWebpackText": true
   },
   "angularCompilerOptions": {
-   "genDir": "./compiled",
-   "skipMetadataEmit": true
+    "genDir": "./compiled",
+    "skipMetadataEmit": true
   },
   "compileOnSave": false,
   "buildOnSave": false,
-  "atom": { "rewriteTsconfig": false }
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }


### PR DESCRIPTION
According to https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url
It should be for non-relative modules

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix ? It probably doesn't really cost anything since we set  "moduleResolution" as "node"

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
