### PR TITLE
Feature #1345 - add autoprefixer support using postcss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 /bower_components/
 npm-debug.log
 /npm-debug.log.*
+yarn.lock
 
 # Coverage #
 /coverage/

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -4,6 +4,7 @@
 
 const webpack = require('webpack');
 const helpers = require('./helpers');
+const autoprefixer = require('autoprefixer');
 
 /*
  * Webpack Plugins
@@ -134,7 +135,7 @@ module.exports = function (options) {
          */
         {
           test: /\.css$/,
-          use: ['to-string-loader', 'css-loader'],
+          use: ['to-string-loader', 'css-loader', 'postcss-loader'],
           exclude: [helpers.root('src', 'styles')]
         },
 
@@ -145,7 +146,7 @@ module.exports = function (options) {
          */
         {
           test: /\.scss$/,
-          use: ['to-string-loader', 'css-loader', 'sass-loader'],
+          use: ['to-string-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
           exclude: [helpers.root('src', 'styles')]
         },
 
@@ -301,7 +302,15 @@ module.exports = function (options) {
        *
        * See: https://gist.github.com/sokra/27b24881210b56bbaff7
        */
-      new LoaderOptionsPlugin({}),
+      new LoaderOptionsPlugin({
+        options: {
+          postcss: [
+            autoprefixer({
+              browsers: ['last 2 version']
+            })
+          ]
+        }
+      }),
 
       // Fix Angular 2
       new NormalModuleReplacementPlugin(

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -95,7 +95,7 @@ module.exports = function (options) {
          */
         {
           test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
+          use: ['style-loader', 'css-loader', 'postcss-loader'],
           include: [helpers.root('src', 'styles')]
         },
 
@@ -106,7 +106,7 @@ module.exports = function (options) {
          */
         {
           test: /\.scss$/,
-          use: ['style-loader', 'css-loader', 'sass-loader'],
+          use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
           include: [helpers.root('src', 'styles')]
         },
 

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -93,7 +93,7 @@ module.exports = function (env) {
           test: /\.css$/,
           loader: ExtractTextPlugin.extract({
               fallbackLoader: 'style-loader',
-              loader: 'css-loader'
+              loader: 'css-loader!postcss-loader'
             }),
           include: [helpers.root('src', 'styles')]
         },
@@ -105,7 +105,7 @@ module.exports = function (env) {
           test: /\.scss$/,
           loader: ExtractTextPlugin.extract({
               fallbackLoader: 'style-loader',
-              loader: 'css-loader!sass-loader'
+              loader: 'css-loader!postcss-loader!sass-loader'
             }),
           include: [helpers.root('src', 'styles')]
         },
@@ -123,7 +123,7 @@ module.exports = function (env) {
 
       /**
        * Plugin: ExtractTextPlugin
-       * Description: Extracts imported CSS files into external stylesheet 
+       * Description: Extracts imported CSS files into external stylesheet
        *
        * See: https://github.com/webpack/extract-text-webpack-plugin
        */

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -131,7 +131,19 @@ module.exports = function (options) {
          */
         {
           test: /\.css$/,
-          loader: ['to-string-loader', 'css-loader'],
+          loader: ['to-string-loader', 'css-loader', 'postcss-loader'],
+          exclude: [helpers.root('src/index.html')]
+        },
+
+        /**
+         * Raw loader support for *.scss files
+         * Returns file content as string
+         *
+         * See: https://github.com/webpack/raw-loader
+         */
+        {
+          test: /\.scss$/,
+          loader: ['to-string-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
           exclude: [helpers.root('src/index.html')]
         },
 

--- a/package.json
+++ b/package.json
@@ -80,10 +80,12 @@
     "@angularclass/conventions-loader": "^1.0.2",
     "@angularclass/hmr": "~1.2.2",
     "@angularclass/hmr-loader": "~3.0.2",
+    "autoprefixer": "^6.6.1",
     "core-js": "^2.4.1",
     "http-server": "^0.9.0",
     "ie-shim": "^0.1.0",
     "jasmine-core": "^2.5.2",
+    "postcss-loader": "^1.2.1",
     "reflect-metadata": "^0.1.9",
     "rxjs": "~5.0.2",
     "zone.js": "~0.7.4"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer')
+  ]
+};
+


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
*feature*

* **What is the current behavior?** (You can also link to an open issue here)
Feature #1345 

* **What is the new behavior (if this is a feature change)?**
AutoPrefixer will add vendor prefixes after this PR is merged.

* **Other information**:
> The `*.scss` loader was missing from `webpack.test.js` which was causing failures if one had scss file in a component.
> It's probably better to add [null-loader](https://github.com/webpack/null-loader) for `*.css` and `*.scss` in test configuration. Maybe we can create a separate PR for that.