### PR TITLE
Remove direct manipulation of the arguments object

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -20,10 +20,7 @@ function isWebpackDevServer() {
   return process.argv[1] && !! (/webpack-dev-server/.exec(process.argv[1]));
 }
 
-function root(args) {
-  args = Array.prototype.slice.call(arguments, 0);
-  return path.join.apply(path, [ROOT].concat(args));
-}
+var root = path.join.bind(path, ROOT);
 
 exports.hasProcessFlag = hasProcessFlag;
 exports.hasNpmFlag = hasNpmFlag;


### PR DESCRIPTION
Fixes #1259

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Style improvement.

* **What is the current behavior?** (You can also link to an open issue here)

Currently the `root` function in the `helpers` module has some unpleasant code deemed necessary for compatibility reasons. It manipulates the arguments object via `Array.prototype.slice.call` and rebinds its actual argument which is a bad practice and is also confusing since the argument's value is ignored and it is effectively used as a variable.

* **What is the new behavior (if this is a feature change)?**

Cleans up the function and reduces code size.

* **Other information**:
