### PR TITLE
Work around TypeScript 2.1.5 bugs in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "add-asset-html-webpack-plugin": "^1.0.2",
     "angular2-template-loader": "^0.6.0",
     "assets-webpack-plugin": "^3.4.0",
-    "awesome-typescript-loader": "~3.0.0-beta.17",
+    "awesome-typescript-loader": "~3.0.0-beta.18",
     "codelyzer": "~2.0.0-beta.4",
     "copy-webpack-plugin": "^4.0.0",
     "css-loader": "^0.26.0",
@@ -149,7 +149,7 @@
     "webpack-dev-server": "2.2.0-rc.0",
     "webpack-dll-bundles-plugin": "^1.0.0-beta.2",
     "webpack-md5-hash": "^0.0.5",
-    "webpack-merge": "~2.3.1"
+    "webpack-merge": "~2.4.0"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,13 @@
       "dom",
       "es6"
     ],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
     "types": [
       "hammerjs",
       "jasmine",
       "node",
-      "selenium-webdriver",
       "source-map",
       "uglify-js",
       "webpack"

--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -14,6 +14,9 @@
       "es2015",
       "dom"
     ],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
     "types": [
       "hammerjs",
       "node"


### PR DESCRIPTION
TypeScript v2.1.5 has several problems in Windows, which don't affect Mac or Linux. This patch introduces workarounds so builds pass on all operating systems.

- Resolves #1353 
- Resolves #1371 
- Minor dependency updates