### PR TITLE
update ngc-webpack to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "2.0.1",
     "ng-router-loader": "^1.0.2",
-    "ngc-webpack": "1.1.0",
+    "ngc-webpack": "~1.1.2",
     "node-sass": "^4.2.0",
     "npm-run-all": "^4.0.0",
     "parse5": "^3.0.1",


### PR DESCRIPTION
This upgrades to ngc-webpack 1.1.2

In 1.1.0 depends on `@angular/tsc-wrapper` and `@angular/compiler-cli`

When `@angular/compiler-cli` bumps `@angular/tsc-wrapper` then **ngc-webpack** needs to do so as well... which is not ideal.

`@angular/compiler-cli` actually is `@angular/tsc-wrapper` since it re-exports all of the tsc-wrapper api... 

1.1.2 uses `@angular/compiler-cli` only.

I had a break when trying to compile a complex setup, took me 1 hour to find the culprit, `@angular/compiler-cli` was using `@angular/tsc-wrapper` 0.5.1 while **ngc-webpack** was using 0.5.0 :/

**Note that for some reason the tests fail on NODE 5, I don't know why yet... so this version is 6+**
The error:
```
  AssertionError: expected [Error: undefined, resolving symbol OpaqueToken in /home/travis/build/shlomiassaf/ngc-webpack/node_modules/@angular/core/src/di/opaque_token.d.ts] to be undefined
```

The build using 2 steps (ngc-w -> webpack) from the cli works!
Just from the plugin it doesn't very strange...

> I'm not sure it's not working on 5, my demo app for integration test might be the issue or it just doesn't work... 