### PR TITLE
feat: use import() construct via ng-router-loader@2.0.0

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -93,17 +93,29 @@ module.exports = function (options) {
       rules: [
 
         /*
-         * Typescript loader support for .ts and Angular 2 async routes via .async.ts
-         * Replace templateUrl and stylesUrl with require()
+         * Typescript loader support for .ts
+         *
+         * Component Template/Style integration using `angular2-template-loader`
+         * Angular 2 lazy loading (async routes) via `ng-router-loader`
+         *
+         * `ng-router-loader` expects vanilla JavaScript code, not TypeScript code. This is why the
+         * order of the loader matter.
          *
          * See: https://github.com/s-panferov/awesome-typescript-loader
          * See: https://github.com/TheLarkInn/angular2-template-loader
+         * See: https://github.com/shlomiassaf/ng-router-loader
          */
         {
           test: /\.ts$/,
           use: [
-            '@angularclass/hmr-loader?pretty=' + !isProd + '&prod=' + isProd,
             {
+              loader: '@angularclass/hmr-loader',
+              options: {
+                pretty: !isProd,
+                prod: isProd
+              }
+            },
+            { // MAKE SURE TO CHAIN VANILLA JS CODE, I.E. TS COMPILATION OUTPUT.
               loader: 'ng-router-loader',
               options: {
                 loader: 'async-import',
@@ -111,9 +123,15 @@ module.exports = function (options) {
                 aot: AOT
               }
             },
-            'awesome-typescript-loader?{configFileName: "tsconfig.webpack.json"}',
-            'angular2-template-loader',
-
+            {
+              loader: 'awesome-typescript-loader',
+              options: {
+                configFileName: 'tsconfig.webpack.json'
+              }
+            },
+            {
+              loader: 'angular2-template-loader'
+            }
           ],
           exclude: [/\.(spec|e2e)\.ts$/]
         },

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -103,16 +103,17 @@ module.exports = function (options) {
           test: /\.ts$/,
           use: [
             '@angularclass/hmr-loader?pretty=' + !isProd + '&prod=' + isProd,
-            'awesome-typescript-loader?{configFileName: "tsconfig.webpack.json"}',
-            'angular2-template-loader',
             {
               loader: 'ng-router-loader',
               options: {
-                loader: 'async-system',
+                loader: 'async-import',
                 genDir: 'compiled',
                 aot: AOT
               }
-            }
+            },
+            'awesome-typescript-loader?{configFileName: "tsconfig.webpack.json"}',
+            'angular2-template-loader',
+
           ],
           exclude: [/\.(spec|e2e)\.ts$/]
         },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "karma-remap-coverage": "^0.1.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "2.0.1",
-    "ng-router-loader": "^1.0.2",
+    "ng-router-loader": "^2.0.0",
     "ngc-webpack": "1.1.0",
     "node-sass": "^4.2.0",
     "npm-run-all": "^4.0.0",
@@ -147,7 +147,7 @@
     "webpack": "2.2.0-rc.4",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-dev-server": "2.2.0-rc.0",
-    "webpack-dll-bundles-plugin": "^1.0.0-beta.2",
+    "webpack-dll-bundles-plugin": "^1.0.0-beta.5",
     "webpack-md5-hash": "^0.0.5",
     "webpack-merge": "~2.4.0"
   },


### PR DESCRIPTION
Support the [Dynamic import proposal](https://github.com/tc39/proposal-dynamic-import) [TC39 Stage 3] as a loader (codegen).
The import() construct is supported in webpack from 2.1.0-beta28

> "async-system" is deprecated in webpack 2 and removed in webpack 3.

Moving to 2.0.0 requires a subtle change in the TS loader order.

**Dev's that just upgrade the packages will have some trouble locating this change in the configs so we might expect some noise**

Reason for change:
Typescript transform `import(...)` syntax into something else.
To use `ng-router-loader` with `async-import` code generator the `ng-router-loader` must
 run **AFTER** the TS compiler (e.g: awesome-typescript-loader), that is in a lower index in the loaders array. If it runs before, TS will see the `import(...` expression and will convert it into invalid code.

This change also requires the code generators to emit ES5 code, all codegen's now emit ES5 code.

SEE: Microsoft/TypeScript#12364