### PR TITLE
Use of v8-lazy-parse-webpack-plugin

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -17,7 +17,6 @@ const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplaceme
 const ProvidePlugin = require('webpack/lib/ProvidePlugin');
 const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
 const WebpackMd5Hash = require('webpack-md5-hash');
-const V8LazyParseWebpackPlugin = require('v8-lazy-parse-webpack-plugin');
 /**
  * Webpack Constants
  */

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "typedoc": "^0.5.3",
     "typescript": "~2.1.5",
     "url-loader": "^0.5.7",
-    "v8-lazy-parse-webpack-plugin": "^0.3.0",
     "webpack": "2.2.0",
     "webpack-dev-middleware": "^1.9.0",
     "webpack-dev-server": "2.2.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Clean prod config / package.json

* **What is the current behavior?** (You can also link to an open issue here)

Currently the **v8-lazy-parse-webpack-plugin** is only referenced in this [file ](https://github.com/AngularClass/angular2-webpack-starter/blob/fa823c2ac46b2d87cf591937c8799b193bd5f216/config/webpack.prod.js#L20) but never used.

Should we either use it or remove dependency (PR subject)?

* **What is the new behavior (if this is a feature change)?**

Remove unused plugin
