### PR TITLE
open page on dev start

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "protractor:live": "protractor --elementExplorer",
     "rimraf": "rimraf",
     "server:dev:hmr": "npm run server:dev -- --inline --hot",
-    "server:dev": "webpack-dev-server --config config/webpack.dev.js --progress --profile --watch --content-base src/",
+    "server:dev": "webpack-dev-server --config config/webpack.dev.js --open --progress --profile --watch --content-base src/",
     "server:prod": "http-server dist -c-1 --cors",
     "server:prod:ci": "http-server dist -p 3000 -c-1 --cors",
     "server": "npm run server:dev",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature - add --open to webpack-dev-server


* **What is the current behavior?** (You can also link to an open issue here)
does not open on `npm start`


* **What is the new behavior (if this is a feature change)?**
webpage will open on `npm start`


* **Other information**:
