### PR TITLE
Fix webpack.dev.js json format error

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -101,9 +101,9 @@ module.exports = function (options) {
                configFile: 'tslint.json'
              }
            }
-         ]
+         ],
          exclude: [/\.(spec|e2e)\.ts$/]
-       }
+       },
 
         /*
          * css loader support for *.css files (styles directory only)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The webpack.dev.js file from config has an invalid format. There are missing commas.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
