### PR TITLE
test: remove unused module

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -3,7 +3,6 @@
  */
 
 const helpers = require('./helpers');
-const path = require('path');
 
 /**
  * Webpack Plugins


### PR DESCRIPTION
* **Other information**:
We don't need `path` module as it is done using `helpers.root`. see [this](https://github.com/AngularClass/angular2-webpack-starter/commit/1ea8b71fe2bc1debe608eb604cb18b35ddda8884) 