### PR TITLE
chore(package): update extract-text-webpack-plugin to version 2.0.0-rc.3

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -96,8 +96,8 @@ module.exports = function (env) {
         {
           test: /\.css$/,
           loader: ExtractTextPlugin.extract({
-            fallbackLoader: 'style-loader',
-            loader: 'css-loader'
+            fallback: 'style-loader',
+            use: 'css-loader'
           }),
           include: [helpers.root('src', 'styles')]
         },
@@ -108,8 +108,8 @@ module.exports = function (env) {
         {
           test: /\.scss$/,
           loader: ExtractTextPlugin.extract({
-            fallbackLoader: 'style-loader',
-            loader: 'css-loader!sass-loader'
+            fallback: 'style-loader',
+            use: 'css-loader!sass-loader'
           }),
           include: [helpers.root('src', 'styles')]
         },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "css-loader": "^0.26.0",
     "exports-loader": "^0.6.3",
     "expose-loader": "^0.7.1",
-    "extract-text-webpack-plugin": "~2.0.0-rc.2",
+    "extract-text-webpack-plugin": "~2.0.0-rc.3",
     "file-loader": "^0.10.0",
     "find-root": "^1.0.0",
     "gh-pages": "^0.12.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

As per `extract-text-webpack-plugin` version [2.0.0-rc.3](https://github.com/webpack-contrib/extract-text-webpack-plugin/releases/tag/v2.0.0-rc.3) following are deprecated.

- `fallbackLoader` is replaced with `fallback`
- `loader` is replaced with `use`

You will get following message on console while building for production `npm run build:aot:prod` 

![msg](https://cloud.githubusercontent.com/assets/2920003/22737081/7879c428-ee27-11e6-8d2f-1ff2ad04c8cc.png)
