### PR TITLE
Webpack config folders alternative structure (WIP - Don't merge yet)

### DIFF
--- a/config/webpack/browser/index.js
+++ b/config/webpack/browser/index.js
@@ -1,0 +1,10 @@
+/*
+ * @author: Michael De Abreu
+ *
+ * Made for @AngularClass
+ */
+
+
+module.exports = (env) => env.prod
+    ? require('./webpack.browser.prod')(env)
+    : require('./webpack.browser.dev')(env);

--- a/config/webpack/browser/webpack.browser.common.js
+++ b/config/webpack/browser/webpack.browser.common.js
@@ -3,42 +3,46 @@
  */
 
 const webpack = require('webpack');
-const helpers = require('./helpers');
+const webpackMerge = require('webpack-merge'); // used to merge webpack configs
+const { resolve } = require('app-root-path');
 
 /*
  * Webpack Plugins
  */
 // problem with copy-webpack-plugin
 const AssetsPlugin = require('assets-webpack-plugin');
-const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
-const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
-const CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
+const {
+  NormalModuleReplacementPlugin,
+  ContextReplacementPlugin,
+  LoaderOptionsPlugin,
+} = require('webpack');
+
+const { CommonsChunkPlugin } = require('webpack').optimize;
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
-const HtmlElementsPlugin = require('./html-elements-plugin');
+const { CheckerPlugin } = require('awesome-typescript-loader');
+const HtmlElementsPlugin = require('./../../html-elements-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const ngcWebpack = require('ngc-webpack');
 
+
+const { HTML_OPTIONS } = require('./../options');
 /*
  * Webpack Constants
  */
-const HMR = helpers.hasProcessFlag('hot');
-const AOT = helpers.hasNpmFlag('aot');
-const METADATA = {
-  title: 'Angular2 Webpack Starter by @gdi2290 from @AngularClass',
-  baseUrl: '/',
-  isDevServer: helpers.isWebpackDevServer()
-};
+
 
 /*
  * Webpack configuration
  *
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
-module.exports = function (options) {
-  isProd = options.env === 'production';
+module.exports = (options) => {
+  /**
+   * Webpack options
+   */
+  const _options = webpackMerge(HTML_OPTIONS, options)
+  const isProd = options.env === 'production';
   return {
 
     /*
@@ -59,8 +63,8 @@ module.exports = function (options) {
     entry: {
 
       'polyfills': './src/polyfills.browser.ts',
-      'main':      AOT ? './src/main.browser.aot.ts' :
-                  './src/main.browser.ts'
+      'main': _options.aot ? './src/main.browser.aot.ts' :
+        './src/main.browser.ts'
 
     },
 
@@ -79,7 +83,7 @@ module.exports = function (options) {
       extensions: ['.ts', '.js', '.json'],
 
       // An array of directory names to be resolved to the current directory
-      modules: [helpers.root('src'), helpers.root('node_modules')],
+      modules: [resolve('src'), resolve('node_modules')],
 
     },
 
@@ -120,7 +124,7 @@ module.exports = function (options) {
               options: {
                 loader: 'async-import',
                 genDir: 'compiled',
-                aot: AOT
+                aot: _options.aot
               }
             },
             {
@@ -154,7 +158,7 @@ module.exports = function (options) {
         {
           test: /\.css$/,
           use: ['to-string-loader', 'css-loader'],
-          exclude: [helpers.root('src', 'styles')]
+          exclude: [resolve('src', 'styles')]
         },
 
         /*
@@ -165,7 +169,7 @@ module.exports = function (options) {
         {
           test: /\.scss$/,
           use: ['to-string-loader', 'css-loader', 'sass-loader'],
-          exclude: [helpers.root('src', 'styles')]
+          exclude: [resolve('src', 'styles')]
         },
 
         /* Raw loader support for *.html
@@ -176,7 +180,7 @@ module.exports = function (options) {
         {
           test: /\.html$/,
           use: 'raw-loader',
-          exclude: [helpers.root('src/index.html')]
+          exclude: [resolve('src/index.html')]
         },
 
         /* File loader for supporting images, for example, in CSS files.
@@ -197,7 +201,7 @@ module.exports = function (options) {
      */
     plugins: [
       new AssetsPlugin({
-        path: helpers.root('dist'),
+        path: resolve('dist'),
         filename: 'webpack-assets.json',
         prettyPrint: true
       }),
@@ -242,7 +246,7 @@ module.exports = function (options) {
       new ContextReplacementPlugin(
         // The (\\|\/) piece accounts for path separators in *nix and Windows
         /angular(\\|\/)core(\\|\/)src(\\|\/)linker/,
-        helpers.root('src'), // location of your src
+        resolve('src'), // location of your src
         {
           // your Angular Async Route paths relative to this root directory
         }
@@ -258,7 +262,7 @@ module.exports = function (options) {
        */
       new CopyWebpackPlugin([
         { from: 'src/assets', to: 'assets' },
-        { from: 'src/meta'}
+        { from: 'src/meta' }
       ]),
 
 
@@ -272,9 +276,9 @@ module.exports = function (options) {
        */
       new HtmlWebpackPlugin({
         template: 'src/index.html',
-        title: METADATA.title,
+        title: _options.title,
         chunksSortMode: 'dependency',
-        metadata: METADATA,
+        metadata: _options,
         inject: 'head'
       }),
 
@@ -312,7 +316,7 @@ module.exports = function (options) {
        * Dependencies: HtmlWebpackPlugin
        */
       new HtmlElementsPlugin({
-        headTags: require('./head-config.common')
+        headTags: require('./../../head-config.common')
       }),
 
       /**
@@ -325,29 +329,29 @@ module.exports = function (options) {
       // Fix Angular 2
       new NormalModuleReplacementPlugin(
         /facade(\\|\/)async/,
-        helpers.root('node_modules/@angular/core/src/facade/async.js')
+        resolve('node_modules/@angular/core/src/facade/async.js')
       ),
       new NormalModuleReplacementPlugin(
         /facade(\\|\/)collection/,
-        helpers.root('node_modules/@angular/core/src/facade/collection.js')
+        resolve('node_modules/@angular/core/src/facade/collection.js')
       ),
       new NormalModuleReplacementPlugin(
         /facade(\\|\/)errors/,
-        helpers.root('node_modules/@angular/core/src/facade/errors.js')
+        resolve('node_modules/@angular/core/src/facade/errors.js')
       ),
       new NormalModuleReplacementPlugin(
         /facade(\\|\/)lang/,
-        helpers.root('node_modules/@angular/core/src/facade/lang.js')
+        resolve('node_modules/@angular/core/src/facade/lang.js')
       ),
       new NormalModuleReplacementPlugin(
         /facade(\\|\/)math/,
-        helpers.root('node_modules/@angular/core/src/facade/math.js')
+        resolve('node_modules/@angular/core/src/facade/math.js')
       ),
 
       new ngcWebpack.NgcWebpackPlugin({
-        disabled: !AOT,
-        tsConfig: helpers.root('tsconfig.webpack.json'),
-        resourceOverride: helpers.root('config/resource-override.js')
+        disabled: !_options.aot,
+        tsConfig: resolve('tsconfig.webpack.json'),
+        resourceOverride: resolve('config/resource-override.js')
       })
 
     ],

--- a/config/webpack/browser/webpack.browser.prod.js
+++ b/config/webpack/browser/webpack.browser.prod.js
@@ -2,41 +2,34 @@
  * @author: @AngularClass
  */
 
-const helpers = require('./helpers');
+const { resolve } = require('app-root-path');
 const webpackMerge = require('webpack-merge'); // used to merge webpack configs
-const commonConfig = require('./webpack.common.js'); // the settings that are common to prod and dev
+const commonConfig = require('./webpack.browser.common'); // the settings that are common to prod and dev
 
 /**
  * Webpack Plugins
  */
-const DefinePlugin = require('webpack/lib/DefinePlugin');
+const {
+  DefinePlugin,
+  IgnorePlugin,
+  LoaderOptionsPlugin,
+  NormalModuleReplacementPlugin,
+  ProvidePlugin,
+} = require('webpack');
+const { UglifyJsPlugin } = require('webpack').optimize;
+
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const IgnorePlugin = require('webpack/lib/IgnorePlugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
-const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
-const ProvidePlugin = require('webpack/lib/ProvidePlugin');
-const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
 const OptimizeJsPlugin = require('optimize-js-plugin');
 
-/**
- * Webpack Constants
- */
-const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
-const HOST = process.env.HOST || 'localhost';
-const PORT = process.env.PORT || 8080;
-const METADATA = webpackMerge(commonConfig({
-  env: ENV
-}).metadata, {
-  host: HOST,
-  port: PORT,
-  ENV: ENV,
-  HMR: false
-});
+const { PROD_OPTIONS } = require('./../options');
 
-module.exports = function (env) {
-  return webpackMerge(commonConfig({
-    env: ENV
-  }), {
+module.exports = (options) => {
+  /**
+   * Webpack options
+   */
+  const _options = webpackMerge(PROD_OPTIONS, options);
+
+  return webpackMerge(commonConfig(_options), {
 
     /**
      * Developer tool to enhance debugging
@@ -58,7 +51,7 @@ module.exports = function (env) {
        *
        * See: http://webpack.github.io/docs/configuration.html#output-path
        */
-      path: helpers.root('dist'),
+      path: resolve('dist'),
 
       /**
        * Specifies the name of each output file on disk.
@@ -99,7 +92,7 @@ module.exports = function (env) {
             fallbackLoader: 'style-loader',
             loader: 'css-loader'
           }),
-          include: [helpers.root('src', 'styles')]
+          include: [resolve('src', 'styles')]
         },
 
         /*
@@ -111,7 +104,7 @@ module.exports = function (env) {
             fallbackLoader: 'style-loader',
             loader: 'css-loader!sass-loader'
           }),
-          include: [helpers.root('src', 'styles')]
+          include: [resolve('src', 'styles')]
         },
 
       ]
@@ -155,12 +148,12 @@ module.exports = function (env) {
        */
       // NOTE: when adding more properties make sure you include them in custom-typings.d.ts
       new DefinePlugin({
-        'ENV': JSON.stringify(METADATA.ENV),
-        'HMR': METADATA.HMR,
+        'ENV': JSON.stringify(_options.ENV),
+        'HMR': _options.HMR,
         'process.env': {
-          'ENV': JSON.stringify(METADATA.ENV),
-          'NODE_ENV': JSON.stringify(METADATA.ENV),
-          'HMR': METADATA.HMR,
+          'ENV': JSON.stringify(_options.ENV),
+          'NODE_ENV': JSON.stringify(_options.ENV),
+          'HMR': _options.HMR,
         }
       }),
 
@@ -219,43 +212,43 @@ module.exports = function (env) {
 
       new NormalModuleReplacementPlugin(
         /angular2-hmr/,
-        helpers.root('config/empty.js')
+        resolve('config/empty.js')
       ),
 
       new NormalModuleReplacementPlugin(
         /zone\.js(\\|\/)dist(\\|\/)long-stack-trace-zone/,
-        helpers.root('config/empty.js')
+        resolve('config/empty.js')
       ),
 
 
       // AoT
       // new NormalModuleReplacementPlugin(
       //   /@angular(\\|\/)upgrade/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
       // new NormalModuleReplacementPlugin(
       //   /@angular(\\|\/)compiler/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
       // new NormalModuleReplacementPlugin(
       //   /@angular(\\|\/)platform-browser-dynamic/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
       // new NormalModuleReplacementPlugin(
       //   /dom(\\|\/)debug(\\|\/)ng_probe/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
       // new NormalModuleReplacementPlugin(
       //   /dom(\\|\/)debug(\\|\/)by/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
       // new NormalModuleReplacementPlugin(
       //   /src(\\|\/)debug(\\|\/)debug_node/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
       // new NormalModuleReplacementPlugin(
       //   /src(\\|\/)debug(\\|\/)debug_renderer/,
-      //   helpers.root('config/empty.js')
+      //   resolve('config/empty.js')
       // ),
 
       /**

--- a/config/webpack/index.js
+++ b/config/webpack/index.js
@@ -1,0 +1,22 @@
+/*
+ * @author: Michael De Abreu
+ *
+ * Made for @AngularClass
+ */
+
+/**
+ * Main webpack config file.
+ *
+ * You can add here more configurations and set the target in the script.
+ */
+
+module.exports = (env) => {
+  env = env || {};
+  switch (env.target) {
+    case 'github':
+      return require('./github')(env);
+    case 'web':
+    default:
+      return require('./browser')(env);
+  }
+}

--- a/config/webpack/options/index.js
+++ b/config/webpack/options/index.js
@@ -1,0 +1,49 @@
+/*
+ * @author: Michael De Abreu
+ *
+ * Made for @AngularClass
+ */
+
+const appRoot = require('app-root-path');
+const hasFlag = require('has-flag');
+
+const isDevServer = process.argv[1] && !! (/webpack-dev-server/.exec(process.argv[1]));
+
+/**
+ * HtmlWebpackPlugin configuration options
+ *
+ */
+const HTML_OPTIONS = {
+  template: appRoot.resolve('src/index.html'),
+  chunksSortMode: 'dependency',
+  title: 'Angular2 Webpack Starter by @gdi2290 from @AngularClass',
+  description: 'Angular 2 Webpack Starter',
+  baseUrl: '/',
+  isDevServer,
+};
+
+/**
+ * Production process configuration options
+ */
+const PROD_OPTIONS = {
+  ENV: process.env.ENV = process.env.NODE_ENV = 'production',
+  HMR: false,
+  host: process.env.HOST || 'localhost',
+  port: process.env.PORT || 8080,
+};
+
+/**
+ * Development process configuration options
+ */
+const DEV_OPTIONS = {
+  ENV: process.env.ENV = process.env.NODE_ENV = 'development',
+  HMR: hasFlag('hot'),
+  host: process.env.HOST || 'localhost',
+  port: process.env.PORT || 3000,
+};
+
+module.exports = {
+  HTML_OPTIONS,
+  DEV_OPTIONS,
+  PROD_OPTIONS,
+};

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "build:aot:prod": "npm run clean:dist && npm run clean:aot && webpack --config config/webpack.prod.js  --progress --profile --bail",
     "build:aot": "npm run build:aot:prod",
-    "build:dev": "npm run clean:dist && webpack --config config/webpack.dev.js --progress --profile",
+    "build:dev": "npm run clean:dist && webpack --progress --profile",
     "build:docker": "npm run build:prod && docker build -t angular2-webpack-start:latest .",
-    "build:prod": "npm run clean:dist && webpack --config config/webpack.prod.js  --progress --profile --bail",
+    "build:prod": "npm run clean:dist && webpack --progress --profile --bail --env.prod",
     "build": "npm run build:dev",
     "ci:aot": "npm run lint && npm run test && npm run build:aot && npm run e2e",
     "ci:jit": "npm run lint && npm run test && npm run build:prod && npm run e2e",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "file-loader": "^0.10.0",
     "find-root": "^1.0.0",
     "gh-pages": "^0.12.0",
+    "has-flag": "^2.0.0",
     "html-webpack-plugin": "^2.28.0",
     "imports-loader": "^0.7.0",
     "istanbul-instrumenter-loader": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/webpack": "^2.0.0",
     "add-asset-html-webpack-plugin": "^1.0.2",
     "angular2-template-loader": "^0.6.0",
+    "app-root-path": "^2.0.1",
     "assets-webpack-plugin": "^3.5.1",
     "awesome-typescript-loader": "~3.0.0-beta.18",
     "codelyzer": "~2.0.0-beta.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,8 @@
 /**
- * @author: @AngularClass
+ * @author: Michael De Abreu
+ *
+ * Made for @AngularClass
  */
 
-// Look in ./config folder for webpack.dev.js
-switch (process.env.NODE_ENV) {
-  case 'prod':
-  case 'production':
-    module.exports = require('./config/webpack.prod')({env: 'production'});
-    break;
-  case 'test':
-  case 'testing':
-    module.exports = require('./config/webpack.test')({env: 'test'});
-    break;
-  case 'dev':
-  case 'development':
-  default:
-    module.exports = require('./config/webpack.dev')({env: 'development'});
-}
+
+module.exports = (env) => require('./config/webpack')(env);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature about the Webpack configuration

* **What is the current behavior?** (You can also link to an open issue here)

The Webpack configuration it's called individually for all the run. This is somehow explicit about the configuration, but it is not good for extends. 

* **What is the new behavior (if this is a feature change)?**

This PR should introduce a new structure for the Webpack configuration folders. This should be easy to understand, and to extend. The webpack should be called without any config argument, and the main Webpack config file should call the Webpack config folder. This `index.js` should be able to resolve the request configuration and return it. 

* **Other information**:

Right now it's a WIP (The build shows errors somehow). 

Ref: #1468 