### PR TITLE
rename selector 'app' to 'app-starter'

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { AppState } from './app.service';
  * Top Level Component
  */
 @Component({
-  selector: 'app',
+  selector: 'app-starter',
   encapsulation: ViewEncapsulation.None,
   styleUrls: [
     './app.component.css'

--- a/src/index.html
+++ b/src/index.html
@@ -22,9 +22,9 @@
 
 <body>
 
-  <app>
+  <app-starter>
     Loading...
-  </app>
+  </app-starter>
 
   <!-- Google Analytics: change UA-71073175-1 to be your site's ID -->
   <script>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

rename selector 'app' to 'app-starter'

* **What is the current behavior?** (You can also link to an open issue here)

'app'


* **What is the new behavior (if this is a feature change)?**

'app-starter'


* **Other information**:

see angular style guide: https://angular.io/styleguide#!#02-07

also, solves html validation error: "Element app not allowed as child of element div in this context. (Suppressing further errors from this subtree.)", see https://validator.w3.org/nu/
