### PR TITLE
rename app selector to 'my-app'

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { AppState } from './app.service';
  * Top Level Component
  */
 @Component({
-  selector: 'app',
+  selector: 'my-app',
   encapsulation: ViewEncapsulation.None,
   styleUrls: [
     './app.component.css'

--- a/src/app/app.e2e.ts
+++ b/src/app/app.e2e.ts
@@ -19,7 +19,7 @@ describe('App', () => {
   });
 
   it('should have <home>', () => {
-    let subject = element(by.css('app home')).isPresent();
+    let subject = element(by.css('my-app home')).isPresent();
     let result  = true;
     expect(subject).toEqual(result);
   });

--- a/src/index.html
+++ b/src/index.html
@@ -22,9 +22,9 @@
 
 <body>
 
-  <app>
+  <my-app>
     Loading...
-  </app>
+  </my-app>
 
   <!-- Google Analytics: change UA-71073175-1 to be your site's ID -->
   <script>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

AppComponent selector is ``app``

* **What is the new behavior (if this is a feature change)?**

AppComponent selector is ``my-app``


* **Other information**:

Uses a hyphenated, lowercase element selector value. Follows [Angular styleguide](https://angular.io/styleguide#!#02-07). Is a [valid custom element name](https://html.spec.whatwg.org/multipage/scripting.html#valid-custom-element-name). Solves [HTML validation error](https://validator.w3.org/nu/): "Element app not allowed as child of element div in this context. (Suppressing further errors from this subtree.)".