### PR TITLE
fixes #1016

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -135,6 +135,17 @@ module.exports = function (options) {
         },
 
         /**
+         * Raw loader support for *.scss files
+         *
+         * See: https://github.com/webpack/raw-loader
+         */
+        {
+            test: /\.scss$/,
+            loader: ['raw-loader', 'sass-loader'],
+            exclude: [helpers.root('src/index.html')]
+        },
+
+        /**
          * Raw loader support for *.html
          * Returns file content as string
          *


### PR DESCRIPTION
This commit fixes #1016.

When a SASS file `@includes` another, then when unit tests are run the following error might be produced:

Uncaught Error: Expected 'styles' to be an array of strings

To reproduce:

```
git clone -b sass-import-unit-test-issue https://github.com/mikechamberlain/angular2-webpack-starter.git
npm install
npm run test
```
