### PR TITLE
Fixes #1628 ~ Fix types/jasmine to 2.5.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@angular/compiler-cli": "2.4.6",
     "@types/hammerjs": "^2.0.33",
-    "@types/jasmine": "^2.2.34",
+    "@types/jasmine": "2.5.45",
     "@types/node": "^7.0.0",
     "@types/selenium-webdriver": "~2.53.39",
     "@types/source-map": "^0.5.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix #1628 


* **What is the current behavior?** (You can also link to an open issue here)
npm run test fail with error 
ERROR in [at-loader] src/app/app.e2e.ts:12:29 
    TS2345: Argument of type 'string' is not assignable to parameter of type 'Expected<Promise<string>>'.


* **What is the new behavior (if this is a feature change)?**
Fixing the typing version fix the build


* **Other information**:
Fixing the typing version seems to be a good practice since it can break the build at any moment